### PR TITLE
Add input validation and some unit tests

### DIFF
--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -318,6 +318,9 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext );
  * @param[in] pMqttAgentContext The MQTT agent to use.
  * @param[in] sessionPresent The session present flag from the broker.
  *
+ * @note This function is NOT thread-safe and should only be called
+ * from the context of the task responsible for #MQTTAgent_CommandLoop.
+ *
  * @return `MQTTSuccess` if it succeeds in resending publishes, else an
  * appropriate error code from `MQTT_Publish()`
  */

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -408,7 +408,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
             }
 
             /* Will the message fit in the defined buffer? */
-            isValid = ( ( pPublishInfo->payloadLength + uxHeaderBytes ) < pMqttAgentContext->mqttContext.networkBuffer.size ) &&
+            isValid = ( uxHeaderBytes < pMqttAgentContext->mqttContext.networkBuffer.size ) &&
                       ( isSpace == true );
 
             break;
@@ -807,7 +807,6 @@ static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
         LogError( ( "Pointer cannot be NULL. pMqttAgentContext=%p, pCommandInfo=%p.",
                     ( void * ) pMqttAgentContext,
                     ( void * ) pCommandInfo ) );
-        ret = false;
     }
     else if( ( pMqttAgentContext->agentInterface.send == NULL ) ||
              ( pMqttAgentContext->agentInterface.recv == NULL ) ||
@@ -816,7 +815,6 @@ static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
              ( pMqttAgentContext->agentInterface.pMsgCtx == NULL ) )
     {
         LogError( ( "pMqttAgentContext must have initialized its messaging interface." ) );
-        ret = false;
     }
     else
     {

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -885,8 +885,8 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
     else if( ( pMsgInterface->pMsgCtx == NULL ) ||
              ( pMsgInterface->send == NULL ) ||
              ( pMsgInterface->recv == NULL ) ||
-             ( pMsgInterface->releaseCommand == NULL ) ||
-             ( pMsgInterface->getCommand == NULL ) )
+             ( pMsgInterface->getCommand == NULL ) ||
+             ( pMsgInterface->releaseCommand == NULL ) )
     {
         LogError( ( "Invalid parameter: pMsgInterface must set all members." ) );
         returnStatus = MQTTBadParameter;

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -163,6 +163,14 @@ MQTTStatus_t MQTTAgentCommand_Connect( MQTTAgentContext_t * pMqttAgentContext,
                         pConnectInfo->timeoutMs,
                         &( pConnectInfo->sessionPresent ) );
 
+    /* Resume a session if one existed, else clear the list of acknowledgments. */
+    if( ret == MQTTSuccess )
+    {
+        LogInfo( ( "Session present flag: %d", pConnectInfo->sessionPresent ) );
+        ret = MQTTAgent_ResumeSession( pMqttAgentContext,
+                                       pConnectInfo->sessionPresent );
+    }
+
     memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
 
     return ret;

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(project_name "mqtt_agent")
 # list the files to mock here
 list(APPEND mock_list
             "${MODULE_ROOT_DIR}/source/dependency/coreMQTT/source/include/core_mqtt.h"
+            "${MODULE_ROOT_DIR}/source/dependency/coreMQTT/source/include/core_mqtt_state.h"
             "${MODULE_ROOT_DIR}/source/include/mqtt_agent_command_functions.h"
         )
 # list the directories your mocks need

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -30,24 +30,49 @@
 #include "unity.h"
 
 /* Include paths for public enums, structures, and macros. */
+#include "mqtt_agent.h"
 
 #include "mock_core_mqtt.h"
+#include "mock_core_mqtt_state.h"
 
 /**
  * @brief MQTT client identifier.
  */
-#define MQTT_CLIENT_IDENTIFIER                 "testclient"
+#define MQTT_CLIENT_IDENTIFIER         "testclient"
 
 /**
  * @brief A sample network context that we set to NULL.
  */
-#define MQTT_SAMPLE_NETWORK_CONTEXT            ( NULL )
+#define MQTT_SAMPLE_NETWORK_CONTEXT    ( NULL )
+
+/**
+ * @brief The agent messaging context.
+ */
+struct AgentMessageContext
+{
+    Command_t * pSentCommand;
+};
 
 /**
  * @brief Time at the beginning of each test. Note that this is not updated with
  * a real clock. Instead, we simply increment this variable.
  */
 static uint32_t globalEntryTime = 0;
+
+/**
+ * @brief The number of times the release command function is called.
+ */
+static uint32_t commandReleaseCallCount = 0;
+
+/**
+ * @brief Message context to use for tests.
+ */
+static AgentMessageContext_t globalMessageContext;
+
+/**
+ * @brief Command struct pointer to return from mocked getCommand.
+ */
+static Command_t * pCommandToReturn;
 
 
 /* ============================   UNITY FIXTURES ============================ */
@@ -56,6 +81,9 @@ static uint32_t globalEntryTime = 0;
 void setUp()
 {
     globalEntryTime = 0;
+    commandReleaseCallCount = 0;
+    globalMessageContext.pSentCommand = NULL;
+    pCommandToReturn = NULL;
 }
 
 /* Called after each test method. */
@@ -74,6 +102,113 @@ int suiteTearDown( int numFailures )
     return numFailures;
 }
 
+/* ========================================================================== */
+
+/**
+ * @brief A mocked send function to send command to agent.
+ */
+static bool mockSend( AgentMessageContext_t * pMsgCtx,
+                      const void * pData,
+                      uint32_t blockTimeMs )
+{
+    Command_t ** pCommandToSend = ( Command_t ** ) pData;
+
+    pMsgCtx->pSentCommand = *pCommandToSend;
+    return true;
+}
+
+static bool mockSendFail( AgentMessageContext_t * pMsgCtx,
+                          const void * pData,
+                          uint32_t blockTimeMs )
+{
+    ( void ) pMsgCtx;
+    ( void ) pData;
+    ( void ) blockTimeMs;
+    return false;
+}
+
+/**
+ * @brief A mocked receive function for the agent to receive commands.
+ */
+static bool mockReceive( AgentMessageContext_t * pMsgCtx,
+                         void * pBuffer,
+                         uint32_t blockTimeMs )
+{
+    Command_t ** pCommandToReceive = ( Command_t ** ) pBuffer;
+
+    *pCommandToReceive = pMsgCtx->pSentCommand;
+    return true;
+}
+
+/**
+ * @brief A mocked function to obtain an allocated command.
+ */
+static Command_t * mockGetCommand( uint32_t blockTimeMs )
+{
+    return pCommandToReturn;
+}
+
+/**
+ * @brief A mocked function to release an allocated command.
+ */
+static bool mockReleaseCommand( Command_t * pCommandToRelease )
+{
+    ( void ) pCommandToRelease;
+    commandReleaseCallCount++;
+    return true;
+}
+
+/**
+ * @brief A mock publish callback function.
+ */
+static void mockPublishCallback( MQTTAgentContext_t * pMqttAgentContext,
+                                 uint16_t packetId,
+                                 MQTTPublishInfo_t * pPublishInfo )
+{
+    ( void ) pMqttAgentContext;
+    ( void ) packetId;
+    ( void ) pPublishInfo;
+}
+
+/**
+ * @brief A mocked timer query function that increments on every call.
+ */
+static uint32_t getTime( void )
+{
+    return globalEntryTime++;
+}
+
+/**
+ * @brief Function to initialize MQTT Agent Context to valid parameters.
+ */
+static void setupAgentContext( MQTTAgentContext_t * pAgentContext )
+{
+    AgentMessageInterface_t messageInterface = { 0 };
+    MQTTFixedBuffer_t networkBuffer = { 0 };
+    TransportInterface_t transportInterface = { 0 };
+    void * incomingPacketContext = NULL;
+    MQTTStatus_t mqttStatus;
+
+    messageInterface.pMsgCtx = &globalMessageContext;
+    messageInterface.send = mockSend;
+    messageInterface.recv = mockReceive;
+    messageInterface.releaseCommand = mockReleaseCommand;
+    messageInterface.getCommand = mockGetCommand;
+
+    MQTT_Init_ExpectAnyArgsAndReturn( MQTTSuccess );
+    mqttStatus = MQTTAgent_Init( pAgentContext,
+                                 &messageInterface,
+                                 &networkBuffer,
+                                 &transportInterface,
+                                 getTime,
+                                 mockPublishCallback,
+                                 incomingPacketContext );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    /* Set packet ID nonzero to indicate initialization. */
+    pAgentContext->mqttContext.nextPacketId = 1U;
+}
+
+/* ========================================================================== */
 
 /**
  * @brief Test that MQTTAgent_Init is able to update the context object correctly.
@@ -81,8 +216,6 @@ int suiteTearDown( int numFailures )
 
 void test_MQTTAgent_Init_Happy_Path( void )
 {
-
-
 }
 
 /**
@@ -90,5 +223,301 @@ void test_MQTTAgent_Init_Happy_Path( void )
  */
 void test_MQTT_Init_Invalid_Params( void )
 {
-    
+}
+
+/* ========================================================================== */
+
+/**
+ * @brief Test that the parameter validation for API functions that create
+ * commands (publish, subscribe, connect, etc.) works as intended.
+ */
+void test_MQTTAgent_API_Create_Command_Invalid_Params( void )
+{
+    MQTTAgentContext_t agentContext = { 0 };
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+
+    setupAgentContext( &agentContext );
+
+    /* Use Terminate since it's one that doesn't have an additional pointer param. */
+    mqttStatus = MQTTAgent_Terminate( &agentContext, NULL );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTTAgent_Terminate( NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Various NULL parameters for the agent interface. */
+    agentContext.agentInterface.send = NULL;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    agentContext.agentInterface.send = mockSend;
+    agentContext.agentInterface.recv = NULL;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    agentContext.agentInterface.recv = mockReceive;
+    agentContext.agentInterface.getCommand = NULL;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    agentContext.agentInterface.getCommand = mockGetCommand;
+    agentContext.agentInterface.releaseCommand = NULL;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    agentContext.agentInterface.releaseCommand = mockReleaseCommand;
+    agentContext.agentInterface.pMsgCtx = NULL;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    agentContext.agentInterface.pMsgCtx = &globalMessageContext;
+    /* Invalid packet ID to indicate uninitialized context. */
+    agentContext.mqttContext.nextPacketId = MQTT_PACKET_ID_INVALID;
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+}
+
+/**
+ * @brief Test error cases when a command cannot be obtained or sent
+ * for API functions that create commands.
+ */
+void test_MQTTAgent_API_Create_Command_Allocation_Error( void )
+{
+    MQTTAgentContext_t agentContext = { 0 };
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
+
+    /* Use Ping since it's one that doesn't have an additional pointer param. */
+    pCommandToReturn = NULL;
+    mqttStatus = MQTTAgent_Ping( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTNoMemory, mqttStatus );
+
+    pCommandToReturn = &command;
+    agentContext.agentInterface.send = mockSendFail;
+    mqttStatus = MQTTAgent_Ping( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
+    /* Test that the command was released. */
+    TEST_ASSERT_EQUAL_INT( 1, commandReleaseCallCount );
+    /* Also test that the command was set. */
+    TEST_ASSERT_EQUAL( PING, command.commandType );
+}
+
+/**
+ * @brief Test that a bad parameter is returned when there
+ * is no more space to store a pending acknowledgment for
+ * a command that expects one.
+ */
+void test_MQTTAgent_API_Create_Command_No_Ack_Space( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+    MQTTSubscribeInfo_t subscribeInfo = { 0 };
+    MQTTAgentSubscribeArgs_t subscribeArgs = { 0 };
+    int i;
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* No space in pending ack list. */
+    for( i = 0; i < MQTT_AGENT_MAX_OUTSTANDING_ACKS; i++ )
+    {
+        agentContext.pPendingAcks[ i ].packetId = ( i + 1 );
+    }
+
+    subscribeArgs.pSubscribeInfo = &subscribeInfo;
+    subscribeArgs.numSubscriptions = 1U;
+    mqttStatus = MQTTAgent_Subscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTNoMemory, mqttStatus );
+}
+
+/**
+ * @brief Test that MQTTAgent_Subscribe() works as intended.
+ */
+void test_MQTTAgent_Subscribe( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+    MQTTSubscribeInfo_t subscribeInfo = { 0 };
+    MQTTAgentSubscribeArgs_t subscribeArgs = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested the generic cases of NULL parameters above,
+     * so here we only need to test one for coverage. */
+    mqttStatus = MQTTAgent_Subscribe( NULL, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTTAgent_Subscribe( &agentContext, NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Incorrect subscribe args. */
+    mqttStatus = MQTTAgent_Subscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    subscribeArgs.pSubscribeInfo = &subscribeInfo;
+    subscribeArgs.numSubscriptions = 0U;
+    mqttStatus = MQTTAgent_Subscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Success case. */
+    subscribeArgs.pSubscribeInfo = &subscribeInfo;
+    subscribeArgs.numSubscriptions = 1U;
+    mqttStatus = MQTTAgent_Subscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( SUBSCRIBE, command.commandType );
+    TEST_ASSERT_EQUAL_PTR( &subscribeArgs, command.pArgs );
+}
+
+/**
+ * @brief Test that MQTTAgent_Unsubscribe() works as intended.
+ */
+void test_MQTTAgent_Unsubscribe( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+    MQTTSubscribeInfo_t subscribeInfo = { 0 };
+    MQTTAgentSubscribeArgs_t subscribeArgs = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested the generic cases of NULL parameters above,
+     * so here we only need to test one for coverage. */
+    mqttStatus = MQTTAgent_Unsubscribe( NULL, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    mqttStatus = MQTTAgent_Unsubscribe( &agentContext, NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Incorrect subscribe args. */
+    mqttStatus = MQTTAgent_Unsubscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    subscribeArgs.pSubscribeInfo = &subscribeInfo;
+    subscribeArgs.numSubscriptions = 0U;
+    mqttStatus = MQTTAgent_Unsubscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Success case. */
+    subscribeArgs.pSubscribeInfo = &subscribeInfo;
+    subscribeArgs.numSubscriptions = 1U;
+    mqttStatus = MQTTAgent_Unsubscribe( &agentContext, &subscribeArgs, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( UNSUBSCRIBE, command.commandType );
+    TEST_ASSERT_EQUAL_PTR( &subscribeArgs, command.pArgs );
+}
+
+/* ========================================================================== */
+
+/**
+ * @brief Test that MQTTAgent_ProcessLoop() works as intended.
+ */
+void test_MQTTAgent_ProcessLoop( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested generic cases of NULL parameters above,
+     * so here we only need to test a few one for coverage. */
+    mqttStatus = MQTTAgent_ProcessLoop( NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Success case. */
+    mqttStatus = MQTTAgent_ProcessLoop( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( PROCESSLOOP, command.commandType );
+    TEST_ASSERT_NULL( command.pArgs );
+}
+
+/**
+ * @brief Test that MQTTAgent_Disconnect() works as intended.
+ */
+void test_MQTTAgent_Disconnect( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested generic cases of NULL parameters above,
+     * so here we only need to test a few one for coverage. */
+    mqttStatus = MQTTAgent_Disconnect( NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Success case. */
+    mqttStatus = MQTTAgent_Disconnect( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( DISCONNECT, command.commandType );
+    TEST_ASSERT_NULL( command.pArgs );
+}
+
+/**
+ * @brief Test that MQTTAgent_Ping() works as intended.
+ */
+void test_MQTTAgent_Ping( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested generic cases of NULL parameters above,
+     * so here we only need to test a few one for coverage. */
+    mqttStatus = MQTTAgent_Ping( NULL, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
+
+    /* Success case. */
+    mqttStatus = MQTTAgent_Ping( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( PING, command.commandType );
+    TEST_ASSERT_NULL( command.pArgs );
+}
+
+/**
+ * @brief Test that MQTTAgent_Terminate() works as intended.
+ */
+void test_MQTTAgent_Terminate( void )
+{
+    MQTTAgentContext_t agentContext;
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
+    pCommandToReturn = &command;
+
+    /* We have already tested cases of NULL parameters with Terminate,
+     * so we only need to test the success case. */
+    mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+    TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );
+    TEST_ASSERT_EQUAL( TERMINATE, command.commandType );
+    TEST_ASSERT_NULL( command.pArgs );
 }

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -307,7 +307,7 @@ void test_MQTTAgent_API_Create_Command_Invalid_Params( void )
  * @brief Test error cases when a command cannot be obtained or sent
  * for API functions that create commands.
  */
-void test_MQTTAgent_API_Create_Command_Allocation_Error( void )
+void test_MQTTAgent_API_Create_Command_Creation_Error( void )
 {
     MQTTAgentContext_t agentContext = { 0 };
     MQTTStatus_t mqttStatus;
@@ -376,8 +376,9 @@ void test_MQTTAgent_Subscribe( void )
     setupAgentContext( &agentContext );
     pCommandToReturn = &command;
 
-    /* We have already tested the generic cases of NULL parameters above,
-     * so here we only need to test one for coverage. */
+    /* We have already tested the generic cases of NULL parameters above in
+     * #test_MQTTAgent_API_Create_Command_Invalid_Params, so here we only need
+     * to test one for coverage. */
     mqttStatus = MQTTAgent_Subscribe( NULL, &subscribeArgs, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
@@ -420,8 +421,9 @@ void test_MQTTAgent_Unsubscribe( void )
     pCommandToReturn = &command;
     commandInfo.cmdCompleteCallback = mockCompletionCallback;
 
-    /* We have already tested the generic cases of NULL parameters above,
-     * so here we only need to test one for coverage. */
+    /* We have already tested the generic cases of NULL parameters above in
+     * #test_MQTTAgent_API_Create_Command_Invalid_Params, so here we only need
+     * to test one for coverage. */
     mqttStatus = MQTTAgent_Unsubscribe( NULL, &subscribeArgs, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
@@ -463,8 +465,9 @@ void test_MQTTAgent_ProcessLoop( void )
     setupAgentContext( &agentContext );
     pCommandToReturn = &command;
 
-    /* We have already tested generic cases of NULL parameters above,
-     * so here we only need to test a few one for coverage. */
+    /* We have already tested the generic cases of NULL parameters above in
+     * #test_MQTTAgent_API_Create_Command_Invalid_Params, so here we only need
+     * to test one for coverage. */
     mqttStatus = MQTTAgent_ProcessLoop( NULL, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
@@ -491,8 +494,9 @@ void test_MQTTAgent_Disconnect( void )
     pCommandToReturn = &command;
     commandInfo.cmdCompleteCallback = mockCompletionCallback;
 
-    /* We have already tested generic cases of NULL parameters above,
-     * so here we only need to test a few one for coverage. */
+    /* We have already tested the generic cases of NULL parameters above in
+     * #test_MQTTAgent_API_Create_Command_Invalid_Params, so here we only need
+     * to test one for coverage. */
     mqttStatus = MQTTAgent_Disconnect( NULL, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
@@ -519,8 +523,9 @@ void test_MQTTAgent_Ping( void )
     pCommandToReturn = &command;
     commandInfo.cmdCompleteCallback = mockCompletionCallback;
 
-    /* We have already tested generic cases of NULL parameters above,
-     * so here we only need to test a few one for coverage. */
+    /* We have already tested the generic cases of NULL parameters above in
+     * #test_MQTTAgent_API_Create_Command_Invalid_Params, so here we only need
+     * to test one for coverage. */
     mqttStatus = MQTTAgent_Ping( NULL, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTBadParameter, mqttStatus );
 
@@ -547,8 +552,9 @@ void test_MQTTAgent_Terminate( void )
     pCommandToReturn = &command;
     commandInfo.cmdCompleteCallback = mockCompletionCallback;
 
-    /* We have already tested cases of NULL parameters with Terminate,
-     * so we only need to test the success case. */
+    /* We have already tested cases of NULL parameters with Terminate in
+     * test_MQTTAgent_API_Create_Command_Invalid_Params,so we only need to
+     * test the success case. */
     mqttStatus = MQTTAgent_Terminate( &agentContext, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     TEST_ASSERT_EQUAL_PTR( &command, globalMessageContext.pSentCommand );

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -309,10 +309,9 @@ void test_MQTT_Init_Invalid_Params( void )
 /* ========================================================================== */
 
 /**
- * @brief Test error cases when a command cannot be obtained or sent
- * for API functions that create commands.
+ * @brief Test error cases when a command cannot be obtained.
  */
-void test_MQTTAgent_API_Create_Command_Creation_Error( void )
+void test_MQTTAgent_Ping_Command_Allocation_Failure( void )
 {
     MQTTAgentContext_t agentContext = { 0 };
     MQTTStatus_t mqttStatus;
@@ -321,10 +320,22 @@ void test_MQTTAgent_API_Create_Command_Creation_Error( void )
 
     setupAgentContext( &agentContext );
 
-    /* Use Ping since it's one that doesn't have an additional pointer param. */
     pCommandToReturn = NULL;
     mqttStatus = MQTTAgent_Ping( &agentContext, &commandInfo );
     TEST_ASSERT_EQUAL( MQTTNoMemory, mqttStatus );
+}
+
+/**
+ * @brief Test error case when a command cannot be enqueued.
+ */
+void test_MQTTAgent_Ping_Command_Send_Failure( void )
+{
+    MQTTAgentContext_t agentContext = { 0 };
+    MQTTStatus_t mqttStatus;
+    CommandInfo_t commandInfo = { 0 };
+    Command_t command = { 0 };
+
+    setupAgentContext( &agentContext );
 
     pCommandToReturn = &command;
     agentContext.agentInterface.send = stubSendFail;
@@ -341,7 +352,7 @@ void test_MQTTAgent_API_Create_Command_Creation_Error( void )
  * is no more space to store a pending acknowledgment for
  * a command that expects one.
  */
-void test_MQTTAgent_API_Create_Command_No_Ack_Space( void )
+void test_MQTTAgent_Subscribe_No_Ack_Space( void )
 {
     MQTTAgentContext_t agentContext;
     MQTTStatus_t mqttStatus;


### PR DESCRIPTION
*Description*:
Adds input validation to most MQTT Agent API functions, and unit tests for the following:
* `MQTTAgent_Subscribe`
* `MQTTAgent_Unsubscribe`
* `MQTTAgent_ProcessLoop`
* `MQTTAgent_Disconnect`
* `MQTTAgent_Ping`
* `MQTTAgent_Terminate`

In the process of writing tests, some changes were made to the source code:
* Some more `NULL` checks.
* `assert`s in favor of `if` checks where the parameter had already been checked for `NULL`
* Some missed calls in `MQTTAgentCommand_Connect` to resume sessions.

`MQTTAgent_Connect` and `MQTTAgent_Publish` still need unit tests, however I thought those should be added later lest this PR grow too large. Coverage of `mqtt_agent.c` is around 33%.

