### PR TITLE
CBMC proof for MQTTAgent_Disconnect

### DIFF
--- a/test/cbmc/include/agent_command_pool_stubs.h
+++ b/test/cbmc/include/agent_command_pool_stubs.h
@@ -1,0 +1,61 @@
+/*
+ * coreMQTT-Agent V1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file agent_command_pool_stubs.h
+ * @brief Stub functions to get and release command structure from a command pool.
+ */
+#ifndef AGENT_COMMAND_POOL_STUBS_H
+#define AGENT_COMMAND_POOL_STUBS_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* mqtt_agent.h must precede including this header. */
+
+/**
+ * @brief Send a message to the specified context.
+ *
+ * @param[in] blockTimeMs The length of time the calling task should remain in the
+ * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
+ * become available should one not be immediately at the time of the call.
+ *
+ * @return A pointer to a Command_t structure if one becomes available before
+ * blockTimeMs time expired, otherwise NULL.
+ */
+Command_t * AgentGetCommandStub( uint32_t blockTimeMs );
+
+/**
+ * @brief Receive a message from the specified context.
+ * Must be thread safe.
+ *
+ * @param[in] pCommandToRelease A pointer to the Command_t structure to return to
+ * the pool.  The structure must first have been obtained by calling
+ * Agent_GetCommand(), otherwise Agent_ReleaseCommand() will
+ * have no effect.
+ *
+ * @return true if the Command_t structure was returned to the pool, otherwise false.
+ */
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease );
+
+#endif /* AGENT_COMMAND_POOL_STUBS_H */

--- a/test/cbmc/include/agent_message_stubs.h
+++ b/test/cbmc/include/agent_message_stubs.h
@@ -1,0 +1,63 @@
+/*
+ * coreMQTT-Agent V1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file agent_message_stubs.h
+ * @brief Stub functions to interact with queues.
+ */
+#ifndef AGENT_MESSAGE_STUBS_H
+#define AGENT_MESSAGE_STUBS_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* mqtt_agent.h must precede including this header. */
+
+/**
+ * @brief Send a message to the specified context.
+ *
+ * @param[in] pMsgCtx An #AgentMessageContext_t.
+ * @param[in] pData Pointer to element to send to queue.
+ * @param[in] blockTimeMs Block time to wait for a send.
+ *
+ * @return `true` if send was successful, else `false`.
+ */
+bool AgentMessageSendStub( AgentMessageContext_t * pMsgCtx,
+                           const void * pData,
+                           uint32_t blockTimeMs );
+
+/**
+ * @brief Receive a message from the specified context.
+ * Must be thread safe.
+ *
+ * @param[in] pMsgCtx An #AgentMessageContext_t.
+ * @param[in] pBuffer Pointer to buffer to write received data.
+ * @param[in] blockTimeMs Block time to wait for a receive.
+ *
+ * @return `true` if receive was successful, else `false`.
+ */
+bool AgentMessageRecvStub( AgentMessageContext_t * pMsgCtx,
+                           void * pBuffer,
+                           uint32_t blockTimeMs );
+
+#endif /* AGENT_MESSAGE_STUBS_H */

--- a/test/cbmc/include/get_time_stub.h
+++ b/test/cbmc/include/get_time_stub.h
@@ -20,21 +20,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* MQTT agent include. */
-#include "mqtt_agent.h"
+/**
+ * @file get_time_stub.h
+ * @brief Stub definition for the application defined callback to retrieve the
+ * current time in milliseconds.
+ */
+#ifndef GET_TIME_STUB_H_
+#define GET_TIME_STUB_H_
 
-#include "mqtt_agent_cbmc_state.h"
+/**
+ * Application defined callback to retrieve the current time in milliseconds.
+ *
+ * @return The current time in milliseconds.
+ */
+uint32_t GetCurrentTimeStub( void );
 
-void harness()
-{
-    MQTTAgentContext_t * pMqttAgentContext;
-    CommandInfo_t * pCommandInfo;
-
-    pMqttAgentContext = allocateMqttAgentContext( NULL );
-    __CPROVER_assume( isValidMqttAgentContext( pMqttAgentContext ) );
-
-    pCommandInfo = malloc( sizeof( CommandInfo_t ) );
-
-    MQTTAgent_Disconnect( pMqttAgentContext,
-                          pCommandInfo );
-}
+#endif /* ifndef GET_TIME_STUB_H_ */

--- a/test/cbmc/include/incoming_publish_callback_stub.h
+++ b/test/cbmc/include/incoming_publish_callback_stub.h
@@ -20,21 +20,25 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* MQTT agent include. */
-#include "mqtt_agent.h"
+/**
+ * @file incoming_publish_callback_stub.h
+ * @brief Stub definition for the application defined MQTT library incoming
+ * publish callback.
+ */
+#ifndef INCOMING_PUBLISH_CALLBACK_STUB_H_
+#define INCOMING_PUBLISH_CALLBACK_STUB_H_
 
-#include "mqtt_agent_cbmc_state.h"
+/* mqtt_agent.h must precede including this header. */
 
-void harness()
-{
-    MQTTAgentContext_t * pMqttAgentContext;
-    CommandInfo_t * pCommandInfo;
+/**
+ * @brief Callback function called when receiving a publish.
+ *
+ * @param[in] pMqttAgentContext The context of the MQTT agent.
+ * @param[in] packetId The packet ID of the received publish.
+ * @param[in] pPublishInfo Deserialized publish information.
+ */
+void IncomingPublishCallbackStub( MQTTAgentContext_t * pContext,
+                                  uint16_t packetId,
+                                  MQTTPublishInfo_t * pPublishInfo );
 
-    pMqttAgentContext = allocateMqttAgentContext( NULL );
-    __CPROVER_assume( isValidMqttAgentContext( pMqttAgentContext ) );
-
-    pCommandInfo = malloc( sizeof( CommandInfo_t ) );
-
-    MQTTAgent_Disconnect( pMqttAgentContext,
-                          pCommandInfo );
-}
+#endif /* ifndef INCOMING_PUBLISH_CALLBACK_STUB_H_ */

--- a/test/cbmc/include/mqtt_agent_cbmc_state.h
+++ b/test/cbmc/include/mqtt_agent_cbmc_state.h
@@ -1,0 +1,76 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file mqtt_agent_cbmc_state.h
+ * @brief Allocation and assumption utilities for the MQTT Agent library CBMC proofs.
+ */
+#ifndef MQTT_AGENT_CBMC_STATE_H_
+#define MQTT_AGENT_CBMC_STATE_H_
+
+#include <stdbool.h>
+
+/* mqtt_agent.h must precede including this header. */
+
+/**
+ * @brief Allocate a #MQTTFixedBuffer_t object.
+ *
+ * @param[in] pBuffer #MQTTFixedBuffer_t object information.
+ *
+ * @return NULL or allocated #MQTTFixedBuffer_t memory.
+ */
+MQTTFixedBuffer_t * allocateMqttFixedBuffer( MQTTFixedBuffer_t * pFixedBuffer );
+
+/**
+ * @brief Validate a #MQTTFixedBuffer_t object.
+ *
+ * @param[in] pBuffer #MQTTFixedBuffer_t object to validate.
+ *
+ * @return True if the #MQTTFixedBuffer_t object is valid, false otherwise.
+ *
+ * @note A NULL object is a valid object. This is for coverage of the NULL
+ * parameter checks in the function under proof.
+ */
+bool isValidMqttFixedBuffer( const MQTTFixedBuffer_t * pFixedBuffer );
+
+/**
+ * @brief Allocate a #MQTTAgentContext_t object.
+ *
+ * @param[in] pContext #MQTTAgentContext_t object information.
+ *
+ * @return NULL or allocated #MQTTAgentContext_t memory.
+ */
+MQTTAgentContext_t* allocateMqttAgentContext( MQTTAgentContext_t * pContext );
+
+/**
+ * @brief Validate a #MQTTAgentContext_t object.
+ *
+ * @param[in] pContext #MQTTAgentContext_t object to validate.
+ *
+ * @return True if the #MQTTAgentContext_t object is valid, false otherwise.
+ *
+ * @note A NULL object is a valid object. This is for coverage of the NULL
+ * parameter checks in the function under proof.
+ */
+bool isValidMqttAgentContext( const MQTTAgentContext_t * pContext );
+
+#endif /* ifndef MQTT_AGENT_CBMC_STATE_H_ */

--- a/test/cbmc/include/network_interface_stubs.h
+++ b/test/cbmc/include/network_interface_stubs.h
@@ -1,0 +1,59 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file network_interface_stubs.h
+ * @brief Stub definitions for the application defined transport interface send
+ * and receive callback.
+ */
+#ifndef NETWORK_INTERFACE_STUBS_H_
+#define NETWORK_INTERFACE_STUBS_H_
+
+/* transport_interface.h must precede including this header. */
+
+/**
+ * @brief Application defined network interface receive function.
+ *
+ * @param[in] pNetworkContext Application defined network interface context.
+ * @param[out] pBuffer MQTT network receive buffer.
+ * @param[in] bytesToRecv MQTT requested bytes.
+ *
+ * @return Any value from INT32_MIN to INT32_MAX.
+ */
+int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
+                                     void * pBuffer,
+                                     size_t bytesToRecv );
+
+/**
+ * @brief Application defined network interface send function.
+ *
+ * @param[in] pNetworkContext Application defined network interface context.
+ * @param[out] pBuffer MQTT network send buffer.
+ * @param[in] bytesToSend Number of bytes to send over the network.
+ *
+ * @return Any value from INT32_MIN to INT32_MAX.
+ */
+int32_t NetworkInterfaceSendStub( NetworkContext_t * pNetworkContext,
+                                  const void * pBuffer,
+                                  size_t bytesToSend );
+
+#endif /* ifndef NETWORK_INTERFACE_STUBS_H_ */

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/MQTTAgent_Disconnect_harness.c
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/MQTTAgent_Disconnect_harness.c
@@ -1,0 +1,37 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent.h"
+
+void harness()
+{
+
+  MQTTAgentContext_t * pMqttAgentContext;
+  CommandInfo_t * pCommandInfo;
+
+  pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+  pCommandInfo = malloc( sizeof( CommandInfo_t ) );
+
+  MQTTAgent_Disconnect( pMqttAgentContext,
+                        pCommandInfo );
+}

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
@@ -20,6 +20,7 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/network_interface_stubs.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/incoming_publish_callback_stub.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/get_time_stub.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/agent_command_pool_stubs.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/agent_message_stubs.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent.c
 PROJECT_SOURCES += $(SRCDIR)/source/dependency/coreMQTT/source/core_mqtt.c

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
@@ -15,6 +15,14 @@ REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_agent_cbmc_state.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/network_interface_stubs.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/incoming_publish_callback_stub.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/get_time_stub.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/agent_command_pool_stubs.c
+
 PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent.c
+PROJECT_SOURCES += $(SRCDIR)/source/dependency/coreMQTT/source/core_mqtt.c
+PROJECT_SOURCES += $(SRCDIR)/source/dependency/coreMQTT/source/core_mqtt_serializer.c
 
 include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgent_Disconnect_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgent_Disconnect
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/README.md
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/README.md
@@ -1,0 +1,20 @@
+MQTTAgent_Disconnect proof
+==============
+
+This directory contains a memory safety proof for MQTTAgent_Disconnect.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgent_Disconnect/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgent_Disconnect/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgent_Disconnect",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -1,0 +1,139 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file mqtt_agent_cbmc_state.c
+ * @brief Implements the functions defined in mqtt_agent_cbmc_state.h.
+ */
+#include <stdint.h>
+#include <stdlib.h>
+#include "mqtt_agent.h"
+#include "mqtt_agent_cbmc_state.h"
+#include "network_interface_stubs.h"
+#include "get_time_stub.h"
+#include "incoming_publish_callback_stub.h"
+#include "agent_message_stubs.h"
+#include "agent_command_pool_stubs.h"
+
+
+MQTTFixedBuffer_t * allocateMqttFixedBuffer( MQTTFixedBuffer_t * pFixedBuffer )
+{
+    if( pFixedBuffer == NULL )
+    {
+        pFixedBuffer = malloc( sizeof( MQTTFixedBuffer_t ) );
+    }
+
+    if( pFixedBuffer != NULL )
+    {
+        __CPROVER_assume( pFixedBuffer->size < CBMC_MAX_OBJECT_SIZE );
+        pFixedBuffer->pBuffer = malloc( pFixedBuffer->size );
+    }
+
+    return pFixedBuffer;
+}
+
+bool isValidMqttFixedBuffer( const MQTTFixedBuffer_t * pFixedBuffer )
+{
+    bool isValid = true;
+
+    if( pFixedBuffer != NULL )
+    {
+        isValid = pFixedBuffer->size < CBMC_MAX_OBJECT_SIZE;
+    }
+
+    return isValid;
+}
+
+MQTTAgentContext_t * allocateMqttAgentContext( MQTTAgentContext_t * pContext )
+{
+    TransportInterface_t * pTransportInterface;
+    MQTTFixedBuffer_t * pNetworkBuffer;
+    AgentMessageInterface_t * pMessageInterface;
+    MQTTStatus_t status = MQTTSuccess;
+    void * pIncomingCallbackContext;
+
+    if( pContext == NULL )
+    {
+        pContext = malloc( sizeof( MQTTAgentContext_t ) );
+    }
+
+    pTransportInterface = malloc( sizeof( TransportInterface_t ) );
+
+    if( pTransportInterface != NULL )
+    {
+        /* The possibility that recv and send callbacks are NULL is tested in the
+         * MQTT_Init proof. MQTT_Init is required to be called before any other
+         * function in core_mqtt.h. */
+        pTransportInterface->recv = NetworkInterfaceReceiveStub;
+        pTransportInterface->send = NetworkInterfaceSendStub;
+    }
+
+    pNetworkBuffer = allocateMqttFixedBuffer( NULL );
+    __CPROVER_assume( isValidMqttFixedBuffer( pNetworkBuffer ) );
+
+    pMessageInterface = malloc( sizeof( AgentMessageInterface_t ) );
+
+    if( pMessageInterface != NULL )
+    {
+        pMessageInterface->send = AgentMessageSendStub;
+        pMessageInterface->recv = AgentMessageRecvStub;
+        pMessageInterface->getCommand = AgentGetCommandStub;
+        pMessageInterface->releaseCommand = Agent_ReleaseCommand;
+    }
+
+    /* It is part of the API contract to call MQTT_Init() with the MQTTContext_t
+     * before any other function in core_mqtt.h. */
+    if( pContext != NULL )
+    {
+        status = MQTTAgent_Init( pContext,
+                                 pMessageInterface,
+                                 pNetworkBuffer,
+                                 pTransportInterface,
+                                 GetCurrentTimeStub,
+                                 IncomingPublishCallbackStub,
+                                 pIncomingCallbackContext );
+    }
+
+    /* If the MQTTAgentContext_t initialization failed, then set the context to NULL
+     * so that function under harness will return immediately upon a NULL
+     * parameter check. */
+    if( status != MQTTSuccess )
+    {
+        pContext = NULL;
+    }
+
+    return pContext;
+}
+
+bool isValidMqttAgentContext( const MQTTAgentContext_t * pContext )
+{
+    bool isValid = false;
+
+    if( pContext != NULL )
+    {
+        isValid = true;
+        isValid = isValid && pContext->mqttContext.networkBuffer.size < CBMC_MAX_OBJECT_SIZE;
+        isValid = isValid && isValidMqttFixedBuffer( &( pContext->mqttContext.networkBuffer ) );
+    }
+
+    return isValid;
+}

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -130,9 +130,7 @@ bool isValidMqttAgentContext( const MQTTAgentContext_t * pContext )
 
     if( pContext != NULL )
     {
-        isValid = true;
-        isValid = isValid && pContext->mqttContext.networkBuffer.size < CBMC_MAX_OBJECT_SIZE;
-        isValid = isValid && isValidMqttFixedBuffer( &( pContext->mqttContext.networkBuffer ) );
+        isValid = isValidMqttFixedBuffer( &( pContext->mqttContext.networkBuffer ) );
     }
 
     return isValid;

--- a/test/cbmc/stubs/agent_command_pool_stubs.c
+++ b/test/cbmc/stubs/agent_command_pool_stubs.c
@@ -20,21 +20,23 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* MQTT agent include. */
+/**
+ * @file agent_command_pool_stubs.h
+ * @brief Stub functions to get and release command structure from a command pool.
+ */
 #include "mqtt_agent.h"
+#include "agent_command_pool_stubs.h"
 
-#include "mqtt_agent_cbmc_state.h"
-
-void harness()
+Command_t * AgentGetCommandStub( uint32_t blockTimeMs )
 {
-    MQTTAgentContext_t * pMqttAgentContext;
-    CommandInfo_t * pCommandInfo;
+    Command_t * pCommand;
 
-    pMqttAgentContext = allocateMqttAgentContext( NULL );
-    __CPROVER_assume( isValidMqttAgentContext( pMqttAgentContext ) );
+    pCommand = malloc( sizeof( Command_t ) );
 
-    pCommandInfo = malloc( sizeof( CommandInfo_t ) );
+    return pCommand;
+}
 
-    MQTTAgent_Disconnect( pMqttAgentContext,
-                          pCommandInfo );
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease )
+{
+    return ( pCommandToRelease != NULL ) ? true : false;
 }

--- a/test/cbmc/stubs/agent_message_stubs.c
+++ b/test/cbmc/stubs/agent_message_stubs.c
@@ -1,0 +1,48 @@
+/*
+ * coreMQTT-Agent V1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file agent_message_stubs.h
+ * @brief Stub functions to interact with queues.
+ */
+
+#include "mqtt_agent.h"
+#include "agent_message_stubs.h"
+
+
+bool AgentMessageSendStub( AgentMessageContext_t * pMsgCtx,
+                           const void * pData,
+                           uint32_t blockTimeMs )
+{
+    /* For the proofs, returning a non deterministic boolean value
+     * will be good enough. */
+    return nondet_bool();
+}
+
+bool AgentMessageRecvStub( AgentMessageContext_t * pMsgCtx,
+                           void * pBuffer,
+                           uint32_t blockTimeMs )
+{
+    /* For the proofs, returning a non deterministic boolean value
+     * will be good enough. */
+    return nondet_bool();
+}

--- a/test/cbmc/stubs/get_time_stub.c
+++ b/test/cbmc/stubs/get_time_stub.c
@@ -20,21 +20,24 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* MQTT agent include. */
-#include "mqtt_agent.h"
+/**
+ * @file get_time_stub.c
+ * @brief A stub to mock the retrieval of current time.
+ */
 
-#include "mqtt_agent_cbmc_state.h"
+#include "core_mqtt.h"
+#include "get_time_stub.h"
 
-void harness()
+uint32_t GetCurrentTimeStub( void )
 {
-    MQTTAgentContext_t * pMqttAgentContext;
-    CommandInfo_t * pCommandInfo;
+    /* There are loops in the MQTT library that rely on the timestamp being
+     * reasonable in order to complete. Returning an unbounded timestamp does
+     * not add value to the proofs as the MQTT library uses the timestamp for
+     * only arithmetic operations. In C arithmetic operations on unsigned
+     * integers are guaranteed to reliably wrap around with no adverse side
+     * effects. If the time returned was unbounded, the loops could be unwound
+     * a large number of times making the proof execution very long. */
+    static uint32_t globalEntryTime = 0;
 
-    pMqttAgentContext = allocateMqttAgentContext( NULL );
-    __CPROVER_assume( isValidMqttAgentContext( pMqttAgentContext ) );
-
-    pCommandInfo = malloc( sizeof( CommandInfo_t ) );
-
-    MQTTAgent_Disconnect( pMqttAgentContext,
-                          pCommandInfo );
+    return ++globalEntryTime;
 }

--- a/test/cbmc/stubs/incoming_publish_callback_stub.c
+++ b/test/cbmc/stubs/incoming_publish_callback_stub.c
@@ -20,21 +20,22 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* MQTT agent include. */
+/**
+ * @file incoming_publish_callback_stub.c
+ * @brief A stub for the incoming publish callback.
+ */
+
 #include "mqtt_agent.h"
+#include "incoming_publish_callback_stub.h"
 
-#include "mqtt_agent_cbmc_state.h"
-
-void harness()
+void IncomingPublishCallbackStub( MQTTAgentContext_t * pMqttAgentContext,
+                                  uint16_t packetId,
+                                  MQTTPublishInfo_t * pPublishInfo )
 {
-    MQTTAgentContext_t * pMqttAgentContext;
-    CommandInfo_t * pCommandInfo;
-
-    pMqttAgentContext = allocateMqttAgentContext( NULL );
-    __CPROVER_assume( isValidMqttAgentContext( pMqttAgentContext ) );
-
-    pCommandInfo = malloc( sizeof( CommandInfo_t ) );
-
-    MQTTAgent_Disconnect( pMqttAgentContext,
-                          pCommandInfo );
+    __CPROVER_assert( pMqttAgentContext != NULL,
+                      "IncomingPublishCallbackStub pMqttAgentContext is not NULL." );
+    __CPROVER_assert( packetId != 0U,
+                      "IncomingPublishCallbackStub packetId is not 0." );
+    __CPROVER_assert( pPublishInfo != NULL,
+                      "IncomingPublishCallbackStub pPublishInfo is not NULL" );
 }

--- a/test/cbmc/stubs/network_interface_stubs.c
+++ b/test/cbmc/stubs/network_interface_stubs.c
@@ -1,0 +1,109 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file network_interface_stubs.c
+ * @brief Stubs to mock sending and receiving over a network interface.
+ */
+
+#include "core_mqtt.h"
+#include "network_interface_stubs.h"
+
+/* An exclusive bound on the times that the NetworkInterfaceSendStub will be
+ * invoked before returning a loop terminating value. This is usually defined
+ * in the Makefile of the harnessed function. */
+#ifndef MAX_NETWORK_SEND_TRIES
+    #define MAX_NETWORK_SEND_TRIES    3
+#endif
+
+/* An exclusive bound on the times that the NetworkInterfaceReceiveStub will
+ * return an unbound value. At this value and beyond, the
+ * NetworkInterfaceReceiveStub will return zero on every call. */
+#ifndef MAX_NETWORK_RECV_TRIES
+    #define MAX_NETWORK_RECV_TRIES    4
+#endif
+
+int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
+                                     void * pBuffer,
+                                     size_t bytesToRecv )
+{
+    __CPROVER_assert( pBuffer != NULL,
+                      "NetworkInterfaceReceiveStub pBuffer is not NULL." );
+
+    __CPROVER_assert( __CPROVER_w_ok( pBuffer, bytesToRecv ),
+                      "NetworkInterfaceReceiveStub pBuffer is writable up to bytesToRecv." );
+
+    __CPROVER_havoc_object( pBuffer );
+
+    int32_t bytesOrError;
+    static size_t tries = 0;
+
+    /* It is a bug for the application defined transport send function to return
+     * more than bytesToRecv. */
+    __CPROVER_assume( bytesOrError <= ( int32_t ) bytesToRecv );
+
+    if( tries < ( MAX_NETWORK_RECV_TRIES - 1 ) )
+    {
+        tries++;
+    }
+    else
+    {
+        bytesOrError = 0;
+    }
+
+    return bytesOrError;
+}
+
+int32_t NetworkInterfaceSendStub( NetworkContext_t * pNetworkContext,
+                                  const void * pBuffer,
+                                  size_t bytesToSend )
+{
+    __CPROVER_assert( pBuffer != NULL,
+                      "NetworkInterfaceSendStub pBuffer is not NULL." );
+
+    /* The number of tries to send the message before this invocation. */
+    static size_t tries = 1;
+
+    int32_t bytesOrError;
+
+    /* It is a bug for the application defined transport send function to return
+     * more than bytesToSend. */
+    __CPROVER_assume( bytesOrError <= ( int32_t ) bytesToSend );
+
+    /* If the maximum tries are reached, then return a timeout. In the MQTT library
+     * this stub is wrapped in a loop that will does not end until the bytesOrError
+     * returned is negative. This means we could loop possibly INT32_MAX
+     * iterations. Looping for INT32_MAX times adds no value to the proof.
+     * What matters is that the MQTT library can handle all the possible values
+     * that could be returned. */
+    if( tries < ( MAX_NETWORK_SEND_TRIES - 1 ) )
+    {
+        tries++;
+    }
+    else
+    {
+        tries = 1;
+        bytesOrError = bytesToSend;
+    }
+
+    return bytesOrError;
+}


### PR DESCRIPTION
CBMC proof for MQTTAgent_Disconnect.

The errors are fixed in the PR #7. This proof should be merged only after the PR #7 is merged and the branch is rebased.