### PR TITLE
Change void * in interface to Command_t **

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -118,6 +118,7 @@ pcommandcompletecallback
 pcommandcompletecallbackcontext
 pcommandinfo
 pcommandtorelease
+pcommandtosend
 pconnectargs
 pconnectinfo
 pcontext
@@ -145,6 +146,7 @@ pparams
 ppendingacks
 ppublisharg
 ppublishinfo
+preceivedcommand
 preturnflags
 preturninfo
 printf

--- a/source/include/agent_message.h
+++ b/source/include/agent_message.h
@@ -35,25 +35,29 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* Declare here so interface functions can use. */
+struct Command;
+typedef struct Command               Command_t;
+
 /**
  * @ingroup mqtt_agent_struct_types
  * @brief Context with which tasks may deliver messages to the agent.
  */
 struct AgentMessageContext;
-typedef struct AgentMessageContext AgentMessageContext_t;
+typedef struct AgentMessageContext   AgentMessageContext_t;
 
 /**
  * @brief Send a message to the specified context.
  * Must be thread safe.
  *
  * @param[in] pMsgCtx An #AgentMessageContext_t.
- * @param[in] pData Pointer to element to send to queue.
+ * @param[in] pCommandToSend Pointer to address to send to queue.
  * @param[in] blockTimeMs Block time to wait for a send.
  *
  * @return `true` if send was successful, else `false`.
  */
 typedef bool ( * AgentMessageSend_t )( AgentMessageContext_t * pMsgCtx,
-                                       const void * pData,
+                                       Command_t * const * pCommandToSend,
                                        uint32_t blockTimeMs );
 
 /**
@@ -61,13 +65,60 @@ typedef bool ( * AgentMessageSend_t )( AgentMessageContext_t * pMsgCtx,
  * Must be thread safe.
  *
  * @param[in] pMsgCtx An #AgentMessageContext_t.
- * @param[in] pBuffer Pointer to buffer to write received data.
+ * @param[out] pReceivedCommand Pointer to write address of received command.
  * @param[in] blockTimeMs Block time to wait for a receive.
  *
  * @return `true` if receive was successful, else `false`.
  */
 typedef bool ( * AgentMessageRecv_t )( AgentMessageContext_t * pMsgCtx,
-                                       void * pBuffer,
+                                       Command_t ** pReceivedCommand,
                                        uint32_t blockTimeMs );
+
+/**
+ * @brief Obtain a Command_t structure.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE. The Command_t structure must persist for the duration of the command's
+ * operation.
+ *
+ * @param[in] blockTimeMs The length of time the calling task should remain in the
+ * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
+ * become available should one not be immediately at the time of the call.
+ *
+ * @return A pointer to a Command_t structure if one becomes available before
+ * blockTimeMs time expired, otherwise NULL.
+ */
+typedef Command_t * ( * AgentCommandGet_t )( uint32_t blockTimeMs );
+
+/**
+ * @brief Give a Command_t structure back to the application.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE. The Command_t structure must persist for the duration of the command's
+ * operation.
+ *
+ * @param[in] pCommandToRelease A pointer to the Command_t structure to return to
+ * the application. The structure must first have been obtained by calling
+ * an #AgentCommandGet_t, otherwise it will have no effect.
+ *
+ * @return true if the Command_t structure was returned to the application, otherwise false.
+ */
+typedef bool ( * AgentCommandRelease_t )( Command_t * pCommandToRelease );
+
+/**
+ * @ingroup mqtt_agent_struct_types
+ * @brief Function pointers and contexts used for sending and receiving commands,
+ * and allocating memory for them.
+ */
+typedef struct AgentMessageInterface
+{
+    AgentMessageContext_t * pMsgCtx;      /**< Context with which tasks may deliver messages to the agent. */
+    AgentMessageSend_t send;              /**< Function to send a command to the agent. */
+    AgentMessageRecv_t recv;              /**< Function for the agent to receive a command. */
+    AgentCommandGet_t getCommand;         /**< Function to obtain a pointer to an allocated command. */
+    AgentCommandRelease_t releaseCommand; /**< Function to release an allocated command. */
+} AgentMessageInterface_t;
 
 #endif /* AGENT_MESSAGE_H */

--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -35,7 +35,7 @@
 #include "core_mqtt.h"
 #include "core_mqtt_state.h"
 
-/* Queue include. */
+/* Command messaging interface include. */
 #include "agent_message.h"
 
 /**
@@ -85,10 +85,7 @@ typedef enum CommandType
 } CommandType_t;
 
 struct MQTTAgentContext;
-typedef struct MQTTAgentContext   MQTTAgentContext_t;
-
-struct Command;
-typedef struct Command            Command_t;
+typedef struct MQTTAgentContext MQTTAgentContext_t;
 
 /**
  * @ingroup mqtt_agent_struct_types
@@ -156,53 +153,6 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,
                                              MQTTPublishInfo_t * pPublishInfo );
-
-/**
- * @brief Obtain a Command_t structure.
- *
- * @note Command_t structures hold everything the MQTT agent needs to process a
- * command that originates from application.  Examples of commands are PUBLISH and
- * SUBSCRIBE. The Command_t structure must persist for the duration of the command's
- * operation.
- *
- * @param[in] blockTimeMs The length of time the calling task should remain in the
- * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
- * become available should one not be immediately at the time of the call.
- *
- * @return A pointer to a Command_t structure if one becomes available before
- * blockTimeMs time expired, otherwise NULL.
- */
-typedef Command_t * ( * AgentCommandGet_t )( uint32_t blockTimeMs );
-
-/**
- * @brief Give a Command_t structure back to the application.
- *
- * @note Command_t structures hold everything the MQTT agent needs to process a
- * command that originates from application.  Examples of commands are PUBLISH and
- * SUBSCRIBE. The Command_t structure must persist for the duration of the command's
- * operation.
- *
- * @param[in] pCommandToRelease A pointer to the Command_t structure to return to
- * the application. The structure must first have been obtained by calling
- * an #AgentCommandGet_t, otherwise it will have no effect.
- *
- * @return true if the Command_t structure was returned to the application, otherwise false.
- */
-typedef bool ( * AgentCommandRelease_t )( Command_t * pCommandToRelease );
-
-/**
- * @ingroup mqtt_agent_struct_types
- * @brief Function pointers and contexts used for sending and receiving commands,
- * and allocating memory for them.
- */
-typedef struct AgentMessageInterface
-{
-    AgentMessageContext_t * pMsgCtx;      /**< Context with which tasks may deliver messages to the agent. */
-    AgentMessageSend_t send;              /**< Function to send a command to the agent. */
-    AgentMessageRecv_t recv;              /**< Function for the agent to receive a command. */
-    AgentCommandGet_t getCommand;         /**< Function to obtain a pointer to an allocated command. */
-    AgentCommandRelease_t releaseCommand; /**< Function to release an allocated command. */
-} AgentMessageInterface_t;
 
 /**
  * @ingroup mqtt_agent_struct_types

--- a/test/unit-test/mqtt_agent_command_functions_utest.c
+++ b/test/unit-test/mqtt_agent_command_functions_utest.c
@@ -99,14 +99,17 @@ static bool stubReceive( AgentMessageContext_t * pMsgCtx,
                          Command_t ** pReceivedCommand,
                          uint32_t blockTimeMs )
 {
+    bool ret = false;
+
     ( void ) blockTimeMs;
 
-    if( receiveCounter == 0 )
+    if( receiveCounter++ == 0 )
     {
         *pReceivedCommand = pMsgCtx->pSentCommand;
+        ret = true;
     }
 
-    return( receiveCounter++ == 0 );
+    return ret;
 }
 
 /**

--- a/test/unit-test/mqtt_agent_command_functions_utest.c
+++ b/test/unit-test/mqtt_agent_command_functions_utest.c
@@ -84,11 +84,9 @@ static uint32_t commandReleaseCallCount = 0;
  * @brief A mocked send function to send commands to the agent.
  */
 static bool stubSend( AgentMessageContext_t * pMsgCtx,
-                      const void * pData,
+                      Command_t * const * pCommandToSend,
                       uint32_t blockTimeMs )
 {
-    Command_t ** pCommandToSend = ( Command_t ** ) pData;
-
     ( void ) blockTimeMs;
     pMsgCtx->pSentCommand = *pCommandToSend;
     return true;
@@ -98,25 +96,17 @@ static bool stubSend( AgentMessageContext_t * pMsgCtx,
  * @brief A mocked receive function for the agent to receive commands.
  */
 static bool stubReceive( AgentMessageContext_t * pMsgCtx,
-                         void * pBuffer,
+                         Command_t ** pReceivedCommand,
                          uint32_t blockTimeMs )
 {
-    Command_t ** pCommandToReceive = ( Command_t ** ) pBuffer;
-
     ( void ) blockTimeMs;
 
     if( receiveCounter == 0 )
     {
-        *pCommandToReceive = pMsgCtx->pSentCommand;
-        receiveCounter++;
-        return true;
+        *pReceivedCommand = pMsgCtx->pSentCommand;
     }
-    else
-    {
-        *pCommandToReceive = NULL;
-        receiveCounter++;
-        return false;
-    }
+
+    return( receiveCounter++ == 0 );
 }
 
 /**

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -137,13 +137,10 @@ int suiteTearDown( int numFailures )
  * @brief A mocked send function to send commands to the agent.
  */
 static bool stubSend( AgentMessageContext_t * pMsgCtx,
-                      const void * pData,
+                      Command_t * const * pCommandToSend,
                       uint32_t blockTimeMs )
 {
-    Command_t ** pCommandToSend = ( Command_t ** ) pData;
-
     ( void ) blockTimeMs;
-
     pMsgCtx->pSentCommand = *pCommandToSend;
     return true;
 }
@@ -153,11 +150,11 @@ static bool stubSend( AgentMessageContext_t * pMsgCtx,
  * Returns failure.
  */
 static bool stubSendFail( AgentMessageContext_t * pMsgCtx,
-                          const void * pData,
+                          Command_t * const * pCommandToSend,
                           uint32_t blockTimeMs )
 {
     ( void ) pMsgCtx;
-    ( void ) pData;
+    ( void ) pCommandToSend;
     ( void ) blockTimeMs;
     return false;
 }
@@ -166,14 +163,11 @@ static bool stubSendFail( AgentMessageContext_t * pMsgCtx,
  * @brief A mocked receive function for the agent to receive commands.
  */
 static bool stubReceive( AgentMessageContext_t * pMsgCtx,
-                         void * pBuffer,
+                         Command_t ** pReceivedCommand,
                          uint32_t blockTimeMs )
 {
-    Command_t ** pCommandToReceive = ( Command_t ** ) pBuffer;
-
     ( void ) blockTimeMs;
-
-    *pCommandToReceive = pMsgCtx->pSentCommand;
+    *pReceivedCommand = pMsgCtx->pSentCommand;
     return true;
 }
 


### PR DESCRIPTION
*Description*:
The `void *` pointers in the messaging interface will always be `Command_t **` double pointers, so this makes that change for increased readability and compile-time type checking.
