### PR TITLE
Resolve most MISRA warnings

### DIFF
--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -291,9 +291,9 @@ struct Command
  */
 /* @[declare_mqtt_agent_init] */
 MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
-                             AgentMessageInterface_t * pMsgInterface,
-                             MQTTFixedBuffer_t * pNetworkBuffer,
-                             TransportInterface_t * pTransportInterface,
+                             const AgentMessageInterface_t * pMsgInterface,
+                             const MQTTFixedBuffer_t * pNetworkBuffer,
+                             const TransportInterface_t * pTransportInterface,
                              MQTTGetCurrentTimeFunc_t getCurrentTimeMs,
                              IncomingPublishCallback_t incomingCallback,
                              void * pIncomingPacketContext );

--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -48,7 +48,7 @@
  * The higher this number is the greater the agent's RAM consumption will be.
  */
 #ifndef MQTT_AGENT_MAX_OUTSTANDING_ACKS
-    #define MQTT_AGENT_MAX_OUTSTANDING_ACKS    ( 20 )
+    #define MQTT_AGENT_MAX_OUTSTANDING_ACKS    ( 20U )
 #endif
 
 /**

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -53,10 +53,6 @@
 
 /*-----------------------------------------------------------*/
 
-static const MQTTAgentCommandFunc_t pCommandFunctionTable[ NUM_COMMANDS ] = MQTT_AGENT_FUNCTION_TABLE;
-
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Track an operation by adding it to a list, indicating it is anticipating
  * an acknowledgment.
@@ -348,6 +344,10 @@ static AckInfo_t * getAwaitingOperation( MQTTAgentContext_t * pAgentContext,
                     ( void * ) pFoundAck->pOriginalCommand ) );
         pFoundAck = NULL;
     }
+    else
+    {
+        /* Empty else MISRA 15.7 */
+    }
 
     return pFoundAck;
 }
@@ -474,6 +474,7 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
                                     Command_t * pCommand,
                                     bool * pEndLoop )
 {
+    const MQTTAgentCommandFunc_t pCommandFunctionTable[ NUM_COMMANDS ] = MQTT_AGENT_FUNCTION_TABLE;
     MQTTStatus_t operationStatus = MQTTSuccess;
     bool ackAdded = false;
     MQTTAgentReturnInfo_t returnInfo;

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -476,12 +476,13 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
 {
     MQTTStatus_t operationStatus = MQTTSuccess;
     bool ackAdded = false;
-    MQTTAgentReturnInfo_t returnInfo = { 0 };
+    MQTTAgentReturnInfo_t returnInfo;
     MQTTAgentCommandFunc_t commandFunction = NULL;
     void * pCommandArgs = NULL;
     const uint32_t processLoopTimeoutMs = 0U;
     MQTTAgentCommandFuncReturns_t commandOutParams = { 0 };
 
+    ( void ) memset( &returnInfo, 0x00, sizeof( MQTTAgentReturnInfo_t ) );
     assert( pMqttAgentContext != NULL );
     assert( pEndLoop != NULL );
 
@@ -559,8 +560,9 @@ static void handleAcks( MQTTAgentContext_t * pAgentContext,
     CommandContext_t * pAckContext = NULL;
     CommandCallback_t ackCallback = NULL;
     uint8_t * pSubackCodes = NULL;
-    MQTTAgentReturnInfo_t returnInfo = { 0U };
+    MQTTAgentReturnInfo_t returnInfo;
 
+    ( void ) memset( &returnInfo, 0x00, sizeof( MQTTAgentReturnInfo_t ) );
     assert( pAckInfo != NULL );
     assert( pAckInfo->pOriginalCommand != NULL );
 
@@ -585,9 +587,9 @@ static void handleAcks( MQTTAgentContext_t * pAgentContext,
 
 static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContext )
 {
-    MQTTAgentContext_t * ret = ( MQTTAgentContext_t * ) pMQTTContext;
+    void * ret = pMQTTContext;
 
-    return ret;
+    return ( MQTTAgentContext_t * ) ret;
 }
 
 /*-----------------------------------------------------------*/
@@ -760,12 +762,14 @@ static MQTTStatus_t resendPublishes( MQTTAgentContext_t * pMqttAgentContext )
 static void clearPendingAcknowledgments( MQTTAgentContext_t * pMqttAgentContext )
 {
     size_t i = 0;
-    MQTTAgentReturnInfo_t returnInfo = { 0U };
+    MQTTAgentReturnInfo_t returnInfo;
     AckInfo_t * pendingAcks;
+
+    ( void ) memset( &returnInfo, 0x00, sizeof( MQTTAgentReturnInfo_t ) );
+    assert( pMqttAgentContext != NULL );
 
     returnInfo.returnCode = MQTTRecvFailed;
 
-    assert( pMqttAgentContext != NULL );
 
     pendingAcks = pMqttAgentContext->pPendingAcks;
 

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -47,7 +47,6 @@
 #include <assert.h>
 
 /* MQTT agent include. */
-#include "core_mqtt.h"
 #include "mqtt_agent.h"
 #include "mqtt_agent_command_functions.h"
 

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -261,7 +261,7 @@ static bool isSpaceInPendingAckList( MQTTAgentContext_t * pAgentContext );
 
 static bool isSpaceInPendingAckList( MQTTAgentContext_t * pAgentContext )
 {
-    AckInfo_t * pendingAcks;
+    const AckInfo_t * pendingAcks;
     bool spaceFound = false;
     size_t i;
 
@@ -864,9 +864,9 @@ static bool validateParams( CommandType_t commandType,
 /*-----------------------------------------------------------*/
 
 MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
-                             AgentMessageInterface_t * pMsgInterface,
-                             MQTTFixedBuffer_t * pNetworkBuffer,
-                             TransportInterface_t * pTransportInterface,
+                             const AgentMessageInterface_t * pMsgInterface,
+                             const MQTTFixedBuffer_t * pNetworkBuffer,
+                             const TransportInterface_t * pTransportInterface,
                              MQTTGetCurrentTimeFunc_t getCurrentTimeMs,
                              IncomingPublishCallback_t incomingCallback,
                              void * pIncomingPacketContext )

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -53,7 +53,7 @@
 
 /*-----------------------------------------------------------*/
 
-const MQTTAgentCommandFunc_t pCommandFunctionTable[ NUM_COMMANDS ] = MQTT_AGENT_FUNCTION_TABLE;
+static const MQTTAgentCommandFunc_t pCommandFunctionTable[ NUM_COMMANDS ] = MQTT_AGENT_FUNCTION_TABLE;
 
 /*-----------------------------------------------------------*/
 
@@ -184,7 +184,7 @@ static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContex
  * @param[in] commandType Type of command.
  * @param[in] pMqttAgentContext Handle of the MQTT connection to use.
  * @param[in] pCommandCompleteCallbackContext Context and necessary structs for command.
- * @param[in] cmdCompleteCallback Callback for when command completes.
+ * @param[in] commandCompleteCallback Callback for when command completes.
  * @param[in] pMqttInfoParam Pointer to command argument.
  * @param[in] blockTimeMs Maximum amount of time in milliseconds to wait (in the
  * Blocked state, so not consuming any CPU time) for the command to be posted to the
@@ -196,7 +196,7 @@ static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContex
 static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
                                          MQTTAgentContext_t * pMqttAgentContext,
                                          void * pMqttInfoParam,
-                                         CommandCallback_t cmdCompleteCallback,
+                                         CommandCallback_t commandCompleteCallback,
                                          CommandContext_t * pCommandCompleteCallbackContext,
                                          uint32_t blockTimeMs );
 
@@ -371,7 +371,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
     assert( pMqttAgentContext != NULL );
     assert( pCommand != NULL );
 
-    memset( pCommand, 0x00, sizeof( Command_t ) );
+    ( void ) memset( pCommand, 0x00, sizeof( Command_t ) );
 
     /* Determine if required parameters are present in context. */
     switch( commandType )
@@ -480,7 +480,6 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
     MQTTAgentCommandFunc_t commandFunction = NULL;
     void * pCommandArgs = NULL;
     const uint32_t processLoopTimeoutMs = 0U;
-    uint8_t commandOutFlags = 0U;
     MQTTAgentCommandFuncReturns_t commandOutParams = { 0 };
 
     assert( pMqttAgentContext != NULL );
@@ -579,7 +578,7 @@ static void handleAcks( MQTTAgentContext_t * pAgentContext,
 
     pAgentContext->agentInterface.releaseCommand( pAckInfo->pOriginalCommand );
     /* Clear the entry from the list. */
-    memset( pAckInfo, 0x00, sizeof( AckInfo_t ) );
+    ( void ) memset( pAckInfo, 0x00, sizeof( AckInfo_t ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -652,18 +651,12 @@ static void mqttEventCallback( MQTTContext_t * pMqttContext,
             case MQTT_PACKET_TYPE_PUBREL:
                 break;
 
-            case MQTT_PACKET_TYPE_PINGRESP:
-
-                /* Nothing to be done from application as library handles
-                 * PINGRESP with the use of MQTT_ProcessLoop API function. */
-                LogWarn( ( "PINGRESP should not be handled by the application "
-                           "callback when using MQTT_ProcessLoop.\n" ) );
-                break;
-
             /* Any other packet type is invalid. */
+            case MQTT_PACKET_TYPE_PINGRESP:
             default:
                 LogError( ( "Unknown packet type received:(%02x).\n",
                             pPacketInfo->type ) );
+                break;
         }
     }
 }
@@ -790,7 +783,7 @@ static void clearPendingAcknowledgments( MQTTAgentContext_t * pMqttAgentContext 
             }
 
             /* Now remove it from the list. */
-            memset( &( pendingAcks[ i ] ), 0x00, sizeof( AckInfo_t ) );
+            ( void ) memset( &( pendingAcks[ i ] ), 0x00, sizeof( AckInfo_t ) );
         }
     }
 }
@@ -894,7 +887,7 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
     }
     else
     {
-        memset( pMqttAgentContext, 0x00, sizeof( MQTTAgentContext_t ) );
+        ( void ) memset( pMqttAgentContext, 0x00, sizeof( MQTTAgentContext_t ) );
 
         returnStatus = MQTT_Init( &( pMqttAgentContext->mqttContext ),
                                   pTransportInterface,

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -227,7 +227,7 @@ MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
 {
     Command_t * pReceivedCommand = NULL;
     bool commandWasReceived = false;
-    MQTTAgentReturnInfo_t returnInfo = { 0 };
+    MQTTAgentReturnInfo_t returnInfo = { 0U };
     AckInfo_t * pendingAcks;
     size_t i;
 

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -228,10 +228,11 @@ MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
 {
     Command_t * pReceivedCommand = NULL;
     bool commandWasReceived = false;
-    MQTTAgentReturnInfo_t returnInfo = { 0U };
+    MQTTAgentReturnInfo_t returnInfo;
     AckInfo_t * pendingAcks;
     size_t i;
 
+    ( void ) memset( &returnInfo, 0x00, sizeof( MQTTAgentReturnInfo_t ) );
     ( void ) pUnusedArg;
 
     assert( pMqttAgentContext != NULL );

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -47,9 +47,10 @@ MQTTStatus_t MQTTAgentCommand_ProcessLoop( MQTTAgentContext_t * pMqttAgentContex
                                            MQTTAgentCommandFuncReturns_t * pReturnFlags )
 {
     ( void ) pUnusedArg;
+    ( void ) pMqttAgentContext;
     assert( pReturnFlags != NULL );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pReturnFlags->runProcessLoop = true;
 
     return MQTTSuccess;
@@ -68,7 +69,7 @@ MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
     assert( pPublishArg != NULL );
     assert( pReturnFlags != NULL );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pPublishInfo = ( MQTTPublishInfo_t * ) ( pPublishArg );
 
     if( pPublishInfo->qos != MQTTQoS0 )
@@ -99,7 +100,7 @@ MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
     assert( pVoidSubscribeArgs != NULL );
     assert( pReturnFlags != NULL );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
     pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
 
@@ -127,7 +128,7 @@ MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContex
     assert( pVoidSubscribeArgs != NULL );
     assert( pReturnFlags != NULL );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
     pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
 
@@ -171,7 +172,7 @@ MQTTStatus_t MQTTAgentCommand_Connect( MQTTAgentContext_t * pMqttAgentContext,
                                        pConnectInfo->sessionPresent );
     }
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
 
     return ret;
 }
@@ -191,7 +192,7 @@ MQTTStatus_t MQTTAgentCommand_Disconnect( MQTTAgentContext_t * pMqttAgentContext
 
     ret = MQTT_Disconnect( &( pMqttAgentContext->mqttContext ) );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pReturnFlags->endLoop = true;
 
     return ret;
@@ -212,7 +213,7 @@ MQTTStatus_t MQTTAgentCommand_Ping( MQTTAgentContext_t * pMqttAgentContext,
 
     ret = MQTT_Ping( &( pMqttAgentContext->mqttContext ) );
 
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
 
     pReturnFlags->runProcessLoop = true;
 
@@ -240,7 +241,7 @@ MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
     pendingAcks = pMqttAgentContext->pPendingAcks;
 
     LogInfo( ( "Terminating command loop.\n" ) );
-    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
     pReturnFlags->endLoop = true;
 
     /* Cancel all operations waiting in the queue. */
@@ -272,7 +273,7 @@ MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
             }
 
             /* Now remove it from the list. */
-            memset( &( pendingAcks[ i ] ), 0x00, sizeof( AckInfo_t ) );
+            ( void ) memset( &( pendingAcks[ i ] ), 0x00, sizeof( AckInfo_t ) );
         }
     }
 

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,0 +1,42 @@
+// MISRA C-2012 Rules
+
+{
+    version : "2.0",
+    standard : "c2012",
+    title: "Coverity MISRA Configuration",
+    deviations : [
+        // Disable the following rules.
+        {
+            deviation: "Directive 4.5",
+            reason: "Allow names that MISRA considers ambiguous."
+        },
+        {
+            deviation: "Directive 4.8",
+            reason: "Allow inclusion of unused types. Header files for coreMQTT, which are needed by all files, define types that are not used by the agent."
+        },
+        {
+            deviation: "Directive 4.9",
+            reason: "Allow inclusion of function like macros. Asserts and logging are done using function like macros."
+        },
+        {
+            deviation: "Rule 2.3",
+            reason: "Allow unused types. coreMQTT Library headers define types intended for the application's use, but are not used by the agent files."
+        },
+        {
+            deviation: "Rule 2.4",
+            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+        },
+        {
+            deviation: "Rule 2.5",
+            reason: "Allow unused macros. coreMQTT Library headers define macros intended for the application's use, but are not used by the agent."
+        },
+        {
+            deviation: "Rule 3.1",
+            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+        },
+        {
+            deviation: "Rule 11.5",
+            reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
+        }
+    ]
+}


### PR DESCRIPTION
*Description*:
Resolves most MISRA warnings, except for:
- 8.7 (external linkage, not resolvable)
- 8.13 (adding const everywhere)
- A few 17.7 (unused return of non void).
 
There are some fixes pending for the agent that will cause some code to be rearranged and some unmodified pointers to be modified, so fixing the remaining warnings right now is premature.

Also adds a MISRA config file.


