### PR TITLE
[MQTT Agent ]Cbmc proofs for Connect, Disconnect, Ping and ProcessLoop Command functions

### DIFF
--- a/test/cbmc/include/mqtt_agent_cbmc_state.h
+++ b/test/cbmc/include/mqtt_agent_cbmc_state.h
@@ -92,4 +92,13 @@ bool isValidMqttAgentContext( const MQTTAgentContext_t * pContext );
  */
 bool isAgentSendCommandFunctionStatus( MQTTStatus_t mqttStatus );
 
+/**
+ * @brief Allocate a #MQTTAgentConnectArgs_t object.
+ *
+ * @param[in] pConnectArgs #MQTTAgentConnectArgs_t object information.
+ *
+ * @return NULL or allocated #MQTTAgentConnectArgs_t memory.
+ */
+MQTTAgentConnectArgs_t * allocateConnectArgs( MQTTAgentConnectArgs_t * pConnectArgs );
+
 #endif /* ifndef MQTT_AGENT_CBMC_STATE_H_ */

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
@@ -27,6 +27,7 @@
 
 /* MQTT agent include. */
 #include "mqtt_agent_command_functions.h"
+#include "mqtt_agent_cbmc_state.h"
 
 void harness()
 {
@@ -38,7 +39,7 @@ void harness()
     __CPROVER_assume( pMqttAgentContext != NULL );
     pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
     __CPROVER_assume( pReturnFlags != NULL );
-    pConnectArgs = malloc( sizeof( MQTTAgentConnectArgs_t ) );
+    pConnectArgs = allocateConnectArgs(NULL);
     __CPROVER_assume( pConnectArgs != NULL );
     MQTTAgentCommand_Connect( pMqttAgentContext, pConnectArgs, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
@@ -1,0 +1,44 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Connect_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Connect function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+    MQTTAgentConnectArgs_t * pConnectArgs;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+    pConnectArgs = malloc(sizeof(MQTTAgentConnectArgs_t));
+    __CPROVER_assume( pConnectArgs != NULL );
+  MQTTAgentCommand_Connect(  pMqttAgentContext,pConnectArgs,pReturnFlags);
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
@@ -30,7 +30,7 @@
 
 void harness()
 {
-MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentContext_t * pMqttAgentContext;
     MQTTAgentCommandFuncReturns_t * pReturnFlags;
     MQTTAgentConnectArgs_t * pConnectArgs;
 
@@ -38,7 +38,7 @@ MQTTAgentContext_t * pMqttAgentContext;
     __CPROVER_assume( pMqttAgentContext != NULL );
     pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
     __CPROVER_assume( pReturnFlags != NULL );
-    pConnectArgs = malloc(sizeof(MQTTAgentConnectArgs_t));
+    pConnectArgs = malloc( sizeof( MQTTAgentConnectArgs_t ) );
     __CPROVER_assume( pConnectArgs != NULL );
-  MQTTAgentCommand_Connect(  pMqttAgentContext,pConnectArgs,pReturnFlags);
+    MQTTAgentCommand_Connect( pMqttAgentContext, pConnectArgs, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/MQTTAgentCommand_Connect_harness.c
@@ -39,7 +39,7 @@ void harness()
     __CPROVER_assume( pMqttAgentContext != NULL );
     pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
     __CPROVER_assume( pReturnFlags != NULL );
-    pConnectArgs = allocateConnectArgs(NULL);
+    pConnectArgs = allocateConnectArgs( NULL );
     __CPROVER_assume( pConnectArgs != NULL );
     MQTTAgentCommand_Connect( pMqttAgentContext, pConnectArgs, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Connect_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Connect
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/Makefile
@@ -15,6 +15,7 @@ REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_agent_cbmc_state.c
 PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
 
 include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/README.md
@@ -3,6 +3,9 @@ MQTTAgentCommand_Connect proof
 
 This directory contains a memory safety proof for MQTTAgentCommand_Connect.
 
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Connect()
+ 
 To run the proof.
 -------------
 

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/README.md
@@ -1,0 +1,20 @@
+MQTTAgentCommand_Connect proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Connect.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Connect/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Connect/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Connect",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/MQTTAgentCommand_Disconnect_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/MQTTAgentCommand_Disconnect_harness.c
@@ -1,0 +1,43 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Disconnect_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Disconnect function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+
+    MQTTAgentCommand_Disconnect( pMqttAgentContext, NULL, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Disconnect_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Disconnect
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/README.md
@@ -3,6 +3,9 @@ MQTTAgentCommand_Disconnect proof
 
 This directory contains a memory safety proof for MQTTAgentCommand_Disconnect.
 
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Disconnect()
+
 To run the proof.
 -------------
 

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/README.md
@@ -1,0 +1,20 @@
+MQTTAgentCommand_Disconnect proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Disconnect.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Disconnect/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Disconnect/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Disconnect",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/MQTTAgentCommand_Ping_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/MQTTAgentCommand_Ping_harness.c
@@ -1,0 +1,42 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Ping_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Ping function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+
+    MQTTAgentCommand_Ping( pMqttAgentContext, NULL, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Ping_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Ping
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/README.md
@@ -1,0 +1,20 @@
+MQTTAgentCommand_Ping proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Ping.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/README.md
@@ -3,6 +3,9 @@ MQTTAgentCommand_Ping proof
 
 This directory contains a memory safety proof for MQTTAgentCommand_Ping.
 
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Ping()
+
 To run the proof.
 -------------
 

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Ping/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Ping/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Ping",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/MQTTAgentCommand_ProcessLoop_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/MQTTAgentCommand_ProcessLoop_harness.c
@@ -1,0 +1,42 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_ProcessLoop_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_ProcessLoop function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+
+    MQTTAgentCommand_ProcessLoop( pMqttAgentContext, NULL, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_ProcessLoop_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_ProcessLoop
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/README.md
@@ -3,6 +3,9 @@ MQTTAgentCommand_ProcessLoop proof
 
 This directory contains a memory safety proof for MQTTAgentCommand_ProcessLoop.
 
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_ProcessLoop()
+
 To run the proof.
 -------------
 

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/README.md
@@ -1,0 +1,20 @@
+MQTTAgentCommand_ProcessLoop proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_ProcessLoop.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_ProcessLoop/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_ProcessLoop",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -146,14 +146,15 @@ bool isAgentSendCommandFunctionStatus( MQTTStatus_t mqttStatus )
 
 MQTTAgentConnectArgs_t * allocateConnectArgs( MQTTAgentConnectArgs_t * pConnectArgs )
 {
-    if(pConnectArgs==NULL){
-        pConnectArgs= malloc(sizeof(MQTTAgentConnectArgs_t));
+    if( pConnectArgs == NULL )
+    {
+        pConnectArgs = malloc( sizeof( MQTTAgentConnectArgs_t ) );
         __CPROVER_assume( pConnectArgs != NULL );
     }
 
-    pConnectArgs->pConnectInfo=malloc(sizeof(MQTTConnectInfo_t));
+    pConnectArgs->pConnectInfo = malloc( sizeof( MQTTConnectInfo_t ) );
     __CPROVER_assume( pConnectArgs->pConnectInfo != NULL );
-    pConnectArgs->pWillInfo=malloc(sizeof(MQTTPublishInfo_t));
+    pConnectArgs->pWillInfo = malloc( sizeof( MQTTPublishInfo_t ) );
 
     return pConnectArgs;
 }

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -143,3 +143,17 @@ bool isAgentSendCommandFunctionStatus( MQTTStatus_t mqttStatus )
             ( mqttStatus == MQTTNoMemory ) ||
             ( mqttStatus == MQTTSendFailed ) );
 }
+
+MQTTAgentConnectArgs_t * allocateConnectArgs( MQTTAgentConnectArgs_t * pConnectArgs )
+{
+    if(pConnectArgs==NULL){
+        pConnectArgs= malloc(sizeof(MQTTAgentConnectArgs_t));
+        __CPROVER_assume( pConnectArgs != NULL );
+    }
+
+    pConnectArgs->pConnectInfo=malloc(sizeof(MQTTConnectInfo_t));
+    __CPROVER_assume( pConnectArgs->pConnectInfo != NULL );
+    pConnectArgs->pWillInfo=malloc(sizeof(MQTTPublishInfo_t));
+
+    return pConnectArgs;
+}


### PR DESCRIPTION
This PR contains the cbmc proofs for the following MQTTAgentCommnad_functions:
1. MQTTAgentCommnad_Connect
2. MQTTAgentCommnad_Disconnect
3. MQTTAgentCommnad_Ping
4. MQTTAgentCommnad_ProcessLoop
