### PR TITLE
[MQTT Agent] Cbmc proofs for Publish, Subscribe, Unsubscribe command functions

### DIFF
--- a/test/cbmc/include/mqtt_agent_cbmc_state.h
+++ b/test/cbmc/include/mqtt_agent_cbmc_state.h
@@ -108,4 +108,13 @@ MQTTAgentConnectArgs_t * allocateConnectArgs( MQTTAgentConnectArgs_t * pConnectA
  */
 void addPendingAcks( MQTTAgentContext_t * pContext );
 
+/**
+ * @brief Allocate a #MQTTAgentSubscribeArgs_t object.
+ *
+ * @param[in] pSubscribeArgs #MQTTAgentSubscribeArgs_t object information.
+ *
+ * @return NULL or allocated #MQTTAgentSubscribeArgs_t memory.
+ */
+MQTTAgentSubscribeArgs_t * allocateSubscribeArgs( MQTTAgentSubscribeArgs_t * pSubscribeArgs );
+
 #endif /* ifndef MQTT_AGENT_CBMC_STATE_H_ */

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
@@ -40,7 +40,6 @@ void harness()
     __CPROVER_assume( pReturnFlags != NULL );
     pPublishArg = malloc( sizeof( MQTTPublishInfo_t ) );
     __CPROVER_assume( pPublishArg != NULL );
-    __CPROVER_assume( pPublishArg->qos == MQTTQoS0 || pPublishArg->qos == MQTTQoS1 );
 
     MQTTAgentCommand_Publish( pMqttAgentContext, pPublishArg, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
@@ -1,0 +1,45 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Publish_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Publish function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+    MQTTPublishInfo_t * pPublishArg;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+    pPublishArg = malloc( sizeof( MQTTPublishInfo_t ) );
+    __CPROVER_assume( pPublishArg != NULL );
+
+    MQTTAgentCommand_Publish( pMqttAgentContext, pPublishArg, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/MQTTAgentCommand_Publish_harness.c
@@ -40,6 +40,7 @@ void harness()
     __CPROVER_assume( pReturnFlags != NULL );
     pPublishArg = malloc( sizeof( MQTTPublishInfo_t ) );
     __CPROVER_assume( pPublishArg != NULL );
+    __CPROVER_assume( pPublishArg->qos == MQTTQoS0 || pPublishArg->qos == MQTTQoS1 );
 
     MQTTAgentCommand_Publish( pMqttAgentContext, pPublishArg, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Publish_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Publish
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/README.md
@@ -1,0 +1,23 @@
+MQTTAgentCommand_Publish proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Publish.
+
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Publish()
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Publish/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Publish/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Publish",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/MQTTAgentCommand_Subscribe_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/MQTTAgentCommand_Subscribe_harness.c
@@ -27,6 +27,7 @@
 
 /* MQTT agent include. */
 #include "mqtt_agent_command_functions.h"
+#include "mqtt_agent_cbmc_state.h"
 
 void harness()
 {
@@ -38,8 +39,7 @@ void harness()
     __CPROVER_assume( pMqttAgentContext != NULL );
     pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
     __CPROVER_assume( pReturnFlags != NULL );
-    pSubscribeArgs = malloc( sizeof( MQTTAgentSubscribeArgs_t ) );
-    __CPROVER_assume( pSubscribeArgs != NULL );
+    pSubscribeArgs = allocateSubscribeArgs( NULL );
 
     MQTTAgentCommand_Subscribe( pMqttAgentContext, pSubscribeArgs, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/MQTTAgentCommand_Subscribe_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/MQTTAgentCommand_Subscribe_harness.c
@@ -1,0 +1,45 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Subscribe_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Subscribe function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+    pSubscribeArgs = malloc( sizeof( MQTTAgentSubscribeArgs_t ) );
+    __CPROVER_assume( pSubscribeArgs != NULL );
+
+    MQTTAgentCommand_Subscribe( pMqttAgentContext, pSubscribeArgs, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Subscribe_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Subscribe
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/Makefile
@@ -15,6 +15,7 @@ REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_agent_cbmc_state.c
 PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
 
 include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/README.md
@@ -1,0 +1,23 @@
+MQTTAgentCommand_Subscribe proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Subscribe.
+
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Subscribe()
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Subscribe/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Subscribe/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Subscribe",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/MQTTAgentCommand_Unsubscribe_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/MQTTAgentCommand_Unsubscribe_harness.c
@@ -27,6 +27,7 @@
 
 /* MQTT agent include. */
 #include "mqtt_agent_command_functions.h"
+#include "mqtt_agent_cbmc_state.h"
 
 void harness()
 {
@@ -38,8 +39,7 @@ void harness()
     __CPROVER_assume( pMqttAgentContext != NULL );
     pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
     __CPROVER_assume( pReturnFlags != NULL );
-    pSubscribeArgs = malloc( sizeof( MQTTAgentSubscribeArgs_t ) );
-    __CPROVER_assume( pSubscribeArgs != NULL );
+    pSubscribeArgs = allocateSubscribeArgs( NULL );
 
     MQTTAgentCommand_Unsubscribe( pMqttAgentContext, pSubscribeArgs, pReturnFlags );
 }

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/MQTTAgentCommand_Unsubscribe_harness.c
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/MQTTAgentCommand_Unsubscribe_harness.c
@@ -1,0 +1,45 @@
+/*
+ * coreMQTT-Agent v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file MQTTAgentCommand_Unsubscribe_harness.c
+ * @brief Implements the proof harness for MQTTAgentCommand_Unsubscribe function.
+ */
+
+/* MQTT agent include. */
+#include "mqtt_agent_command_functions.h"
+
+void harness()
+{
+    MQTTAgentContext_t * pMqttAgentContext;
+    MQTTAgentCommandFuncReturns_t * pReturnFlags;
+    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
+
+    pMqttAgentContext = malloc( sizeof( MQTTAgentContext_t ) );
+    __CPROVER_assume( pMqttAgentContext != NULL );
+    pReturnFlags = malloc( sizeof( MQTTAgentCommandFuncReturns_t ) );
+    __CPROVER_assume( pReturnFlags != NULL );
+    pSubscribeArgs = malloc( sizeof( MQTTAgentSubscribeArgs_t ) );
+    __CPROVER_assume( pSubscribeArgs != NULL );
+
+    MQTTAgentCommand_Unsubscribe( pMqttAgentContext, pSubscribeArgs, pReturnFlags );
+}

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = MQTTAgentCommand_Unsubscribe_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = MQTTAgentCommand_Unsubscribe
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/Makefile
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/Makefile
@@ -15,6 +15,7 @@ REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_agent_cbmc_state.c
 PROJECT_SOURCES += $(SRCDIR)/source/mqtt_agent_command_functions.c
 
 include ../Makefile.common

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/README.md
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/README.md
@@ -1,0 +1,23 @@
+MQTTAgentCommand_Unsubscribe proof
+==============
+
+This directory contains a memory safety proof for MQTTAgentCommand_Unsubscribe.
+
+The proof runs within 10 seconds on a t2.2xlarge. It provides complete coverage of:
+ * MQTTAgentCommand_Unsubscribe()
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/cbmc-proof.txt
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTTAgentCommand_Unsubscribe/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "MQTTAgentCommand_Unsubscribe",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -199,4 +199,17 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
 
         pContext->pPendingAcks[ i ].pOriginalCommand = pCommand;
     }
+
+MQTTAgentSubscribeArgs_t * allocateSubscribeArgs( MQTTAgentSubscribeArgs_t * pSubscribeArgs )
+{
+    if( pSubscribeArgs == NULL )
+    {
+        pSubscribeArgs = malloc( sizeof( MQTTAgentSubscribeArgs_t ) );
+        __CPROVER_assume( pSubscribeArgs != NULL );
+    }
+
+    pSubscribeArgs->pSubscribeInfo = malloc( sizeof( MQTTSubscribeInfo_t ) );
+    __CPROVER_assume( pSubscribeArgs->pSubscribeInfo != NULL );
+
+    return pSubscribeArgs;
 }

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -177,7 +177,6 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
     for( i = 0; i < MQTT_AGENT_MAX_OUTSTANDING_ACKS; i++ )
     {
         #ifdef MAX_PACKET_ID
-
             /* Limit the packet Ids so that the range of packet ids retrieved through
              * MQTT_PublishToResend can be limited as well. */
             __CPROVER_assume( packetId < MAX_PACKET_ID );
@@ -199,6 +198,7 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
 
         pContext->pPendingAcks[ i ].pOriginalCommand = pCommand;
     }
+}
 
 MQTTAgentSubscribeArgs_t * allocateSubscribeArgs( MQTTAgentSubscribeArgs_t * pSubscribeArgs )
 {

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -177,7 +177,7 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
     for( i = 0; i < MQTT_AGENT_MAX_OUTSTANDING_ACKS; i++ )
     {
         #ifdef MAX_PACKET_ID
-            
+
             /* Limit the packet Ids so that the range of packet ids retrieved through
              * MQTT_PublishToResend can be limited as well. */
             __CPROVER_assume( packetId < MAX_PACKET_ID );

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -177,6 +177,7 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
     for( i = 0; i < MQTT_AGENT_MAX_OUTSTANDING_ACKS; i++ )
     {
         #ifdef MAX_PACKET_ID
+        
             /* Limit the packet Ids so that the range of packet ids retrieved through
              * MQTT_PublishToResend can be limited as well. */
             __CPROVER_assume( packetId < MAX_PACKET_ID );

--- a/test/cbmc/sources/mqtt_agent_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_agent_cbmc_state.c
@@ -177,7 +177,7 @@ void addPendingAcks( MQTTAgentContext_t * pContext )
     for( i = 0; i < MQTT_AGENT_MAX_OUTSTANDING_ACKS; i++ )
     {
         #ifdef MAX_PACKET_ID
-        
+            
             /* Limit the packet Ids so that the range of packet ids retrieved through
              * MQTT_PublishToResend can be limited as well. */
             __CPROVER_assume( packetId < MAX_PACKET_ID );


### PR DESCRIPTION
This PR contains the cbmc proofs for the following MQTTAgentCommand_functions:
1. MQTTAgentCommand_Publish
2. MQTTAgentCommnad_Subscribe
3. MQTTAgentCommnad_Unsubscribe