### PR TITLE
Address warnings and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
           make -C build/ all
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,10 @@ jobs:
           declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*" "\*dependency\*")
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-# Commenting out the coverage check until coverage reaches 100%. Since the coverage is not 100%
-# now, this check will fail the entire job and any underlying build issues will be masked.
-#      - name: Check Coverage
-#        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
-#        with:
-#          path: ./build/coverage.info
+      - name: Check Coverage
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        with:
+          path: ./build/coverage.info
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -349,9 +349,9 @@ MQTTStatus_t MQTTAgent_ResumeSession( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_subscribe] */
-MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Subscribe( const MQTTAgentContext_t * pMqttAgentContext,
                                   MQTTAgentSubscribeArgs_t * pSubscriptionArgs,
-                                  CommandInfo_t * pCommandInfo );
+                                  const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_subscribe] */
 
 /**
@@ -374,9 +374,9 @@ MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_unsubscribe] */
-MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Unsubscribe( const MQTTAgentContext_t * pMqttAgentContext,
                                     MQTTAgentSubscribeArgs_t * pSubscriptionArgs,
-                                    CommandInfo_t * pCommandInfo );
+                                    const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_unsubscribe] */
 
 /**
@@ -399,9 +399,9 @@ MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_publish] */
-MQTTStatus_t MQTTAgent_Publish( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Publish( const MQTTAgentContext_t * pMqttAgentContext,
                                 MQTTPublishInfo_t * pPublishInfo,
-                                CommandInfo_t * pCommandInfo );
+                                const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_publish] */
 
 /**
@@ -422,8 +422,8 @@ MQTTStatus_t MQTTAgent_Publish( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_processloop] */
-MQTTStatus_t MQTTAgent_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
-                                    CommandInfo_t * pCommandInfo );
+MQTTStatus_t MQTTAgent_ProcessLoop( const MQTTAgentContext_t * pMqttAgentContext,
+                                    const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_processloop] */
 
 /**
@@ -445,8 +445,8 @@ MQTTStatus_t MQTTAgent_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_ping] */
-MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
-                             CommandInfo_t * pCommandInfo );
+MQTTStatus_t MQTTAgent_Ping( const MQTTAgentContext_t * pMqttAgentContext,
+                             const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_ping] */
 
 /**
@@ -470,9 +470,9 @@ MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_connect] */
-MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Connect( const MQTTAgentContext_t * pMqttAgentContext,
                                 MQTTAgentConnectArgs_t * pConnectArgs,
-                                CommandInfo_t * pCommandInfo );
+                                const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_connect] */
 
 /**
@@ -494,8 +494,8 @@ MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_disconnect] */
-MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
-                                   CommandInfo_t * pCommandInfo );
+MQTTStatus_t MQTTAgent_Disconnect( const MQTTAgentContext_t * pMqttAgentContext,
+                                   const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_disconnect] */
 
 /**
@@ -517,8 +517,8 @@ MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_terminate] */
-MQTTStatus_t MQTTAgent_Terminate( MQTTAgentContext_t * pMqttAgentContext,
-                                  CommandInfo_t * pCommandInfo );
+MQTTStatus_t MQTTAgent_Terminate( const MQTTAgentContext_t * pMqttAgentContext,
+                                  const CommandInfo_t * pCommandInfo );
 /* @[declare_mqtt_agent_terminate] */
 
 #endif /* MQTT_AGENT_H */

--- a/source/include/mqtt_agent_command_functions.h
+++ b/source/include/mqtt_agent_command_functions.h
@@ -39,7 +39,9 @@
  * execute.
  */
 #ifndef MQTT_AGENT_FUNCTION_TABLE
-    #define MQTT_AGENT_FUNCTION_TABLE                   \
+    /* Designated initializers are only in C99+. */
+    #if defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L )
+        #define MQTT_AGENT_FUNCTION_TABLE               \
     {                                                   \
         [ NONE ] = MQTTAgentCommand_ProcessLoop,        \
         [ PROCESSLOOP ] = MQTTAgentCommand_ProcessLoop, \
@@ -51,6 +53,23 @@
         [ DISCONNECT ] = MQTTAgentCommand_Disconnect,   \
         [ TERMINATE ] = MQTTAgentCommand_Terminate      \
     }
+    #else /* if defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) */
+
+        /* If not using designated initializers, this must correspond
+         * to the order of CommandType_t commands. */
+        #define MQTT_AGENT_FUNCTION_TABLE \
+    {                                     \
+        MQTTAgentCommand_ProcessLoop,     \
+        MQTTAgentCommand_ProcessLoop,     \
+        MQTTAgentCommand_Publish,         \
+        MQTTAgentCommand_Subscribe,       \
+        MQTTAgentCommand_Unsubscribe,     \
+        MQTTAgentCommand_Ping,            \
+        MQTTAgentCommand_Connect,         \
+        MQTTAgentCommand_Disconnect,      \
+        MQTTAgentCommand_Terminate        \
+    }
+    #endif /* if defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) */
 #endif /* ifndef MQTT_AGENT_FUNCTION_TABLE */
 
 /*-----------------------------------------------------------*/

--- a/source/include/mqtt_agent_command_functions.h
+++ b/source/include/mqtt_agent_command_functions.h
@@ -55,8 +55,8 @@
     }
     #else /* if defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) */
 
-        /* If not using designated initializers, this must correspond
-         * to the order of CommandType_t commands. */
+/* If not using designated initializers, this must correspond
+ * to the order of CommandType_t commands. */
         #define MQTT_AGENT_FUNCTION_TABLE \
     {                                     \
         MQTTAgentCommand_ProcessLoop,     \

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -111,7 +111,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
  * @return MQTTSuccess if the command was added to the queue, else an enumerated
  * error code.
  */
-static MQTTStatus_t addCommandToQueue( MQTTAgentContext_t * pAgentContext,
+static MQTTStatus_t addCommandToQueue( const MQTTAgentContext_t * pAgentContext,
                                        Command_t * pCommand,
                                        uint32_t blockTimeMs );
 
@@ -158,7 +158,7 @@ static void mqttEventCallback( MQTTContext_t * pMqttContext,
  * PUBACK, or PUBCOMP.
  */
 static void handleAcks( MQTTAgentContext_t * pAgentContext,
-                        MQTTPacketInfo_t * pPacketInfo,
+                        const MQTTPacketInfo_t * pPacketInfo,
                         MQTTDeserializedInfo_t * pDeserializedInfo,
                         AckInfo_t * pAckInfo,
                         uint8_t packetType );
@@ -204,7 +204,7 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
  * @param[in] returnCode Return status of command.
  * @param[in] pSubackCodes Pointer to suback array, if command is a SUBSCRIBE.
  */
-static void concludeCommand( MQTTAgentContext_t * pAgentContext,
+static void concludeCommand( const MQTTAgentContext_t * pAgentContext,
                              Command_t * pCommand,
                              MQTTStatus_t returnCode,
                              uint8_t * pSubackCodes );
@@ -268,11 +268,11 @@ static bool validateParams( CommandType_t commandType,
  * @return true if there is space in that MQTT connection's ACK list, otherwise
  * false;
  */
-static bool isSpaceInPendingAckList( MQTTAgentContext_t * pAgentContext );
+static bool isSpaceInPendingAckList( const MQTTAgentContext_t * pAgentContext );
 
 /*-----------------------------------------------------------*/
 
-static bool isSpaceInPendingAckList( MQTTAgentContext_t * pAgentContext )
+static bool isSpaceInPendingAckList( const MQTTAgentContext_t * pAgentContext )
 {
     const AckInfo_t * pendingAcks;
     bool spaceFound = false;
@@ -382,7 +382,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
 {
     bool isValid, isSpace = true;
     MQTTStatus_t statusReturn;
-    MQTTPublishInfo_t * pPublishInfo;
+    const MQTTPublishInfo_t * pPublishInfo;
     size_t uxHeaderBytes;
     const size_t uxControlAndLengthBytes = ( size_t ) 4; /* Control, remaining length and length bytes. */
 
@@ -408,7 +408,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
             break;
 
         case PUBLISH:
-            pPublishInfo = ( MQTTPublishInfo_t * ) pMqttInfoParam;
+            pPublishInfo = ( const MQTTPublishInfo_t * ) pMqttInfoParam;
 
             /* Calculate the space consumed by everything other than the
              * payload. */
@@ -464,7 +464,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t addCommandToQueue( MQTTAgentContext_t * pAgentContext,
+static MQTTStatus_t addCommandToQueue( const MQTTAgentContext_t * pAgentContext,
                                        Command_t * pCommand,
                                        uint32_t blockTimeMs )
 {
@@ -564,7 +564,7 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
 /*-----------------------------------------------------------*/
 
 static void handleAcks( MQTTAgentContext_t * pAgentContext,
-                        MQTTPacketInfo_t * pPacketInfo,
+                        const MQTTPacketInfo_t * pPacketInfo,
                         MQTTDeserializedInfo_t * pDeserializedInfo,
                         AckInfo_t * pAckInfo,
                         uint8_t packetType )
@@ -728,7 +728,7 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
 
 /*-----------------------------------------------------------*/
 
-static void concludeCommand( MQTTAgentContext_t * pAgentContext,
+static void concludeCommand( const MQTTAgentContext_t * pAgentContext,
                              Command_t * pCommand,
                              MQTTStatus_t returnCode,
                              uint8_t * pSubackCodes )

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -382,7 +382,6 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
 {
     bool isValid, isSpace = true;
     MQTTStatus_t statusReturn;
-    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
     MQTTPublishInfo_t * pPublishInfo;
     size_t uxHeaderBytes;
     const size_t uxControlAndLengthBytes = ( size_t ) 4; /* Control, remaining length and length bytes. */
@@ -404,7 +403,6 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
              * the array contains space for another outstanding ack. */
             isSpace = isSpaceInPendingAckList( pMqttAgentContext );
 
-            pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) pMqttInfoParam;
             isValid = isSpace;
 
             break;

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -189,7 +189,7 @@ static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContex
  * Otherwise an enumerated error code.
  */
 static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
-                                         MQTTAgentContext_t * pMqttAgentContext,
+                                         const MQTTAgentContext_t * pMqttAgentContext,
                                          void * pMqttInfoParam,
                                          CommandCallback_t commandCompleteCallback,
                                          CommandContext_t * pCommandCompleteCallbackContext,
@@ -249,7 +249,7 @@ static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
  * @return `true` if parameter structure is valid, else `false`.
  */
 static bool validateParams( CommandType_t commandType,
-                            void * pParams );
+                            const void * pParams );
 
 /**
  * @brief Called before accepting any PUBLISH or SUBSCRIBE messages to check
@@ -669,7 +669,7 @@ static void mqttEventCallback( MQTTContext_t * pMqttContext,
 /*-----------------------------------------------------------*/
 
 static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
-                                         MQTTAgentContext_t * pMqttAgentContext,
+                                         const MQTTAgentContext_t * pMqttAgentContext,
                                          void * pMqttInfoParam,
                                          CommandCallback_t commandCompleteCallback,
                                          CommandContext_t * pCommandCompleteCallbackContext,
@@ -860,7 +860,7 @@ static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
 /*-----------------------------------------------------------*/
 
 static bool validateParams( CommandType_t commandType,
-                            void * pParams )
+                            const void * pParams )
 {
     bool ret = false;
     const MQTTAgentConnectArgs_t * pConnectArgs = NULL;

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -1028,9 +1028,9 @@ MQTTStatus_t MQTTAgent_ResumeSession( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Subscribe( const MQTTAgentContext_t * pMqttAgentContext,
                                   MQTTAgentSubscribeArgs_t * pSubscriptionArgs,
-                                  CommandInfo_t * pCommandInfo )
+                                  const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1053,9 +1053,9 @@ MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Unsubscribe( const MQTTAgentContext_t * pMqttAgentContext,
                                     MQTTAgentSubscribeArgs_t * pSubscriptionArgs,
-                                    CommandInfo_t * pCommandInfo )
+                                    const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1078,9 +1078,9 @@ MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Publish( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Publish( const MQTTAgentContext_t * pMqttAgentContext,
                                 MQTTPublishInfo_t * pPublishInfo,
-                                CommandInfo_t * pCommandInfo )
+                                const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1103,8 +1103,8 @@ MQTTStatus_t MQTTAgent_Publish( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
-                                    CommandInfo_t * pCommandInfo )
+MQTTStatus_t MQTTAgent_ProcessLoop( const MQTTAgentContext_t * pMqttAgentContext,
+                                    const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1126,9 +1126,9 @@ MQTTStatus_t MQTTAgent_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
+MQTTStatus_t MQTTAgent_Connect( const MQTTAgentContext_t * pMqttAgentContext,
                                 MQTTAgentConnectArgs_t * pConnectArgs,
-                                CommandInfo_t * pCommandInfo )
+                                const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1151,8 +1151,8 @@ MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
-                                   CommandInfo_t * pCommandInfo )
+MQTTStatus_t MQTTAgent_Disconnect( const MQTTAgentContext_t * pMqttAgentContext,
+                                   const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1174,8 +1174,8 @@ MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
-                             CommandInfo_t * pCommandInfo )
+MQTTStatus_t MQTTAgent_Ping( const MQTTAgentContext_t * pMqttAgentContext,
+                             const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;
@@ -1197,8 +1197,8 @@ MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTTAgent_Terminate( MQTTAgentContext_t * pMqttAgentContext,
-                                  CommandInfo_t * pCommandInfo )
+MQTTStatus_t MQTTAgent_Terminate( const MQTTAgentContext_t * pMqttAgentContext,
+                                  const CommandInfo_t * pCommandInfo )
 {
     MQTTStatus_t statusReturn = MQTTBadParameter;
     bool paramsValid = false;

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -236,8 +236,8 @@ static void clearPendingAcknowledgments( MQTTAgentContext_t * pMqttAgentContext 
  *
  * @return `true` if parameters are valid, else `false`.
  */
-static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
-                            CommandInfo_t * pCommandInfo );
+static bool validateStruct( const MQTTAgentContext_t * pMqttAgentContext,
+                            const CommandInfo_t * pCommandInfo );
 
 /**
  * @brief Validate the parameters for a CONNECT, SUBSCRIBE, UNSUBSCRIBE
@@ -829,8 +829,8 @@ static void clearPendingAcknowledgments( MQTTAgentContext_t * pMqttAgentContext 
 
 /*-----------------------------------------------------------*/
 
-static bool validateStruct( MQTTAgentContext_t * pMqttAgentContext,
-                            CommandInfo_t * pCommandInfo )
+static bool validateStruct( const MQTTAgentContext_t * pMqttAgentContext,
+                            const CommandInfo_t * pCommandInfo )
 {
     bool ret = false;
 

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -93,7 +93,7 @@ static AckInfo_t * getAwaitingOperation( MQTTAgentContext_t * pAgentContext,
  * else an enumerated error code.
  */
 static MQTTStatus_t createCommand( CommandType_t commandType,
-                                   MQTTAgentContext_t * pMqttAgentContext,
+                                   const MQTTAgentContext_t * pMqttAgentContext,
                                    void * pMqttInfoParam,
                                    CommandCallback_t commandCompleteCallback,
                                    CommandContext_t * pCommandCompleteCallbackContext,
@@ -157,9 +157,9 @@ static void mqttEventCallback( MQTTContext_t * pMqttContext,
  * @param[in] packetType The type of the incoming packet, either SUBACK, UNSUBACK,
  * PUBACK, or PUBCOMP.
  */
-static void handleAcks( MQTTAgentContext_t * pAgentContext,
+static void handleAcks( const MQTTAgentContext_t * pAgentContext,
                         const MQTTPacketInfo_t * pPacketInfo,
-                        MQTTDeserializedInfo_t * pDeserializedInfo,
+                        const MQTTDeserializedInfo_t * pDeserializedInfo,
                         AckInfo_t * pAckInfo,
                         uint8_t packetType );
 
@@ -374,7 +374,7 @@ static AckInfo_t * getAwaitingOperation( MQTTAgentContext_t * pAgentContext,
 /*-----------------------------------------------------------*/
 
 static MQTTStatus_t createCommand( CommandType_t commandType,
-                                   MQTTAgentContext_t * pMqttAgentContext,
+                                   const MQTTAgentContext_t * pMqttAgentContext,
                                    void * pMqttInfoParam,
                                    CommandCallback_t commandCompleteCallback,
                                    CommandContext_t * pCommandCompleteCallbackContext,
@@ -563,9 +563,9 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
 
 /*-----------------------------------------------------------*/
 
-static void handleAcks( MQTTAgentContext_t * pAgentContext,
+static void handleAcks( const MQTTAgentContext_t * pAgentContext,
                         const MQTTPacketInfo_t * pPacketInfo,
-                        MQTTDeserializedInfo_t * pDeserializedInfo,
+                        const MQTTDeserializedInfo_t * pDeserializedInfo,
                         AckInfo_t * pAckInfo,
                         uint8_t packetType )
 {
@@ -863,8 +863,8 @@ static bool validateParams( CommandType_t commandType,
                             void * pParams )
 {
     bool ret = false;
-    MQTTAgentConnectArgs_t * pConnectArgs = NULL;
-    MQTTAgentSubscribeArgs_t * pSubscribeArgs = NULL;
+    const MQTTAgentConnectArgs_t * pConnectArgs = NULL;
+    const MQTTAgentSubscribeArgs_t * pSubscribeArgs = NULL;
 
     assert( ( commandType == CONNECT ) || ( commandType == PUBLISH ) ||
             ( commandType == SUBSCRIBE ) || ( commandType == UNSUBSCRIBE ) );
@@ -872,14 +872,14 @@ static bool validateParams( CommandType_t commandType,
     switch( commandType )
     {
         case CONNECT:
-            pConnectArgs = ( MQTTAgentConnectArgs_t * ) pParams;
+            pConnectArgs = ( const MQTTAgentConnectArgs_t * ) pParams;
             ret = ( ( pConnectArgs != NULL ) &&
                     ( pConnectArgs->pConnectInfo != NULL ) );
             break;
 
         case SUBSCRIBE:
         case UNSUBSCRIBE:
-            pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) pParams;
+            pSubscribeArgs = ( const MQTTAgentSubscribeArgs_t * ) pParams;
             ret = ( ( pSubscribeArgs != NULL ) &&
                     ( pSubscribeArgs->pSubscribeInfo != NULL ) &&
                     ( pSubscribeArgs->numSubscriptions != 0U ) );

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -101,7 +101,7 @@ MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
                                        void * pPublishArg,
                                        MQTTAgentCommandFuncReturns_t * pReturnFlags )
 {
-    MQTTPublishInfo_t * pPublishInfo;
+    const MQTTPublishInfo_t * pPublishInfo;
     MQTTStatus_t ret;
 
     assert( pMqttAgentContext != NULL );
@@ -109,7 +109,7 @@ MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
     assert( pReturnFlags != NULL );
 
     ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
-    pPublishInfo = ( MQTTPublishInfo_t * ) ( pPublishArg );
+    pPublishInfo = ( const MQTTPublishInfo_t * ) ( pPublishArg );
 
     if( pPublishInfo->qos != MQTTQoS0 )
     {
@@ -132,7 +132,7 @@ MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
                                          void * pVoidSubscribeArgs,
                                          MQTTAgentCommandFuncReturns_t * pReturnFlags )
 {
-    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
+    const MQTTAgentSubscribeArgs_t * pSubscribeArgs;
     MQTTStatus_t ret;
 
     assert( pMqttAgentContext != NULL );
@@ -140,7 +140,7 @@ MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
     assert( pReturnFlags != NULL );
 
     ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
-    pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
+    pSubscribeArgs = ( const MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
     pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
 
     ret = MQTT_Subscribe( &( pMqttAgentContext->mqttContext ),
@@ -160,7 +160,7 @@ MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContex
                                            void * pVoidSubscribeArgs,
                                            MQTTAgentCommandFuncReturns_t * pReturnFlags )
 {
-    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
+    const MQTTAgentSubscribeArgs_t * pSubscribeArgs;
     MQTTStatus_t ret;
 
     assert( pMqttAgentContext != NULL );
@@ -168,7 +168,7 @@ MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContex
     assert( pReturnFlags != NULL );
 
     ( void ) memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
-    pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
+    pSubscribeArgs = ( const MQTTAgentSubscribeArgs_t * ) ( pVoidSubscribeArgs );
     pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
 
     ret = MQTT_Unsubscribe( &( pMqttAgentContext->mqttContext ),

--- a/source/mqtt_agent_command_functions.c
+++ b/source/mqtt_agent_command_functions.c
@@ -48,10 +48,10 @@
  * @param[in] pAgentContext Agent context for the MQTT connection.
  * @param[in] pCommand Command to complete.
  */
-static void concludeCommandAsError( MQTTAgentContext_t * pAgentContext,
+static void concludeCommandAsError( const MQTTAgentContext_t * pAgentContext,
                                     Command_t * pCommand );
 
-static void concludeCommandAsError( MQTTAgentContext_t * pAgentContext,
+static void concludeCommandAsError( const MQTTAgentContext_t * pAgentContext,
                                     Command_t * pCommand )
 {
     bool commandReleased = false;

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -287,8 +287,9 @@ MQTTStatus_t MQTT_ProcessLoop_FailSecondAndLaterCallsStub( MQTTContext_t * pCont
 {
     MQTTPacketInfo_t packetInfo;
     MQTTDeserializedInfo_t deserializedInfo;
-    MQTTAgentContext_t * pMqttAgentContext;
     MQTTStatus_t status;
+
+    ( void ) timeoutMs;
 
     packetInfo.type = packetType;
     deserializedInfo.packetIdentifier = packetIdentifier;
@@ -669,7 +670,7 @@ void test_MQTTAgent_Subscribe_No_Ack_Space( void )
     Command_t command = { 0 };
     MQTTSubscribeInfo_t subscribeInfo = { 0 };
     MQTTAgentSubscribeArgs_t subscribeArgs = { 0 };
-    int i;
+    size_t i;
 
     setupAgentContext( &agentContext );
     pCommandToReturn = &command;
@@ -863,7 +864,7 @@ void test_MQTTAgent_Publish_No_Ack_Space( void )
     CommandInfo_t commandInfo = { 0 };
     Command_t command = { 0 };
     MQTTPublishInfo_t publishInfo = { 0 };
-    int i;
+    size_t i;
 
     setupAgentContext( &agentContext );
     pCommandToReturn = &command;

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -347,7 +347,7 @@ static void setupAgentContext( MQTTAgentContext_t * pAgentContext )
  * @param[in] FuncToTest Pointer to function to test.
  * @param[in] pFuncName String of function name to print for error messages.
  */
-static void invalidParamsTestFunc( MQTTStatus_t ( * FuncToTest )( MQTTAgentContext_t *, CommandInfo_t * ),
+static void invalidParamsTestFunc( MQTTStatus_t ( * FuncToTest )( const MQTTAgentContext_t *, const CommandInfo_t * ),
                                    const char * pFuncName )
 {
     MQTTAgentContext_t agentContext = { 0 };


### PR DESCRIPTION
*Description*:
Fixes build warnings, increases coverage, and addresses some MISRA violations. Each change is a separate commit.

* Fix build warnings as a result of using designated initializers for declaring the function pointer. This adds a preprocessor check for C99 before using the designated initializers, and normal initialization if using C90. Both forms are included per Richard's request.
* Enables the `-Werror` flag for CI as all build warnings are resolved.
* Increases unit test coverage to 100% and enables the CI coverage check.
* Resolves all MISRA warnings with the current config except for 8.7 and some 8.13. 8.7 can't be resolved as API functions must be externally linked, and the remaining 8.13 warnings can't be resolved as functions must have an identical signature to the typedef'ed function pointer, so `const` can't be added anywhere.
* Some files will fail the formatting check on the latest version of `uncrustify`. This was done because CI uses an outdated version. The CI check fails if the files are formatted with the latest version of `uncrustify`.

