### PR TITLE
Add doxygen GA and link to MQTT documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,14 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/complexity@main
         with:
           path: ./
+  doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run doxygen build
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
+        with:
+          path: ./
   spell-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           # We don't need to generate the coreMQTT docs, we only need the tag file. We can just download it.
           mkdir -p source/dependency/coreMQTT/docs/doxygen/output
           wget -O source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag \
-          "https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/mqtt.tag"
+          "https://freertos.org/Documentation/api-ref/coreMQTT/docs/doxygen/output/mqtt.tag"
       - name: Run doxygen build
         uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Download MQTT tag
+        run: |
+          # We don't need to generate the coreMQTT docs, we only need the tag file. We can just download it.
+          mkdir -p source/dependency/coreMQTT/docs/doxygen/output
+          wget -O source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag \
+          "https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/mqtt.tag"
       - name: Run doxygen build
         uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
         with:

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2226,7 +2226,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag=https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2226,7 +2226,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag=https://docs.aws.amazon.com/embedded-csdk/202103.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html
+TAGFILES               = source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag=https://freertos.org/Documentation/api-ref/coreMQTT/docs/doxygen/output/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,6 +1,6 @@
 /**
 @mainpage Overview
-@anchor mqtt
+@anchor mqtt_agent
 @brief Thread safe MQTT 3.1.1 client
 
 The coreMQTT Agent is a thread-safe library to serialize calls to coreMQTT, to be executed by a single thread. It provides APIs for a single, dedicated agent task to process coreMQTT related commands, and the APIs for other tasks to enqueue these commands for processing.
@@ -11,7 +11,7 @@ coreMQTT is an MIT licensed open source C MQTT client library for microcontrolle
 */
 
 /**
-@page core_mqtt_config Configurations
+@page core_mqtt_agent_config Configurations
 @brief Configurations of the MQTT Agent.
 <!-- @par configpagestyle allows the @section titles to be styled according to style.css -->
 @par configpagestyle

--- a/source/include/mqtt_agent.h
+++ b/source/include/mqtt_agent.h
@@ -249,7 +249,7 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
  *
  * @param[in] pMqttAgentContext The MQTT agent to use.
  *
- * @return appropriate error code, or `MQTTSuccess` from a successful disconnect
+ * @return appropriate error code, or #MQTTSuccess from a successful disconnect
  * or termination.
  */
 /* @[declare_mqtt_agent_commandloop] */
@@ -266,7 +266,7 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext );
  * @note This function is NOT thread-safe and should only be called
  * from the context of the task responsible for #MQTTAgent_CommandLoop.
  *
- * @return `MQTTSuccess` if it succeeds in resending publishes, else an
+ * @return #MQTTSuccess if it succeeds in resending publishes, else an
  * appropriate error code from `MQTT_Publish()`
  */
 /* @[declare_mqtt_agent_resumesession] */
@@ -290,7 +290,7 @@ MQTTStatus_t MQTTAgent_ResumeSession( MQTTAgentContext_t * pMqttAgentContext,
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_subscribe] */
@@ -315,7 +315,7 @@ MQTTStatus_t MQTTAgent_Subscribe( const MQTTAgentContext_t * pMqttAgentContext,
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_unsubscribe] */
@@ -340,7 +340,7 @@ MQTTStatus_t MQTTAgent_Unsubscribe( const MQTTAgentContext_t * pMqttAgentContext
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_publish] */
@@ -363,7 +363,7 @@ MQTTStatus_t MQTTAgent_Publish( const MQTTAgentContext_t * pMqttAgentContext,
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_processloop] */
@@ -386,7 +386,7 @@ MQTTStatus_t MQTTAgent_ProcessLoop( const MQTTAgentContext_t * pMqttAgentContext
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_ping] */
@@ -411,7 +411,7 @@ MQTTStatus_t MQTTAgent_Ping( const MQTTAgentContext_t * pMqttAgentContext,
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_connect] */
@@ -435,7 +435,7 @@ MQTTStatus_t MQTTAgent_Connect( const MQTTAgentContext_t * pMqttAgentContext,
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_disconnect] */
@@ -458,7 +458,7 @@ MQTTStatus_t MQTTAgent_Disconnect( const MQTTAgentContext_t * pMqttAgentContext,
  * @p pCommandInfo parameter MUST remain in scope at least until the callback
  * has been executed by the agent task.
  *
- * @return `MQTTSuccess` if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 /* @[declare_mqtt_agent_terminate] */

--- a/source/include/mqtt_agent_command_functions.h
+++ b/source/include/mqtt_agent_command_functions.h
@@ -195,7 +195,7 @@ MQTTStatus_t MQTTAgentCommand_Ping( MQTTAgentContext_t * pMqttAgentContext,
  * @param[in] pUnusedArg Unused NULL argument.
  * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
  *
- * @return `MQTTSuccess`.
+ * @return #MQTTSuccess.
  */
 MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
                                          void * pUnusedArg,

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -81,7 +81,7 @@ static AckInfo_t * getAwaitingOperation( MQTTAgentContext_t * pAgentContext,
                                          uint16_t incomingPacketId );
 
 /**
- * @brief Populate the parameters of a #Command_t
+ * @brief Populate the parameters of a #Command struct.
  *
  * @param[in] commandType Type of command.  For example, publish or subscribe.
  * @param[in] pMqttAgentContext Pointer to MQTT context to use for command.
@@ -117,7 +117,7 @@ static MQTTStatus_t addCommandToQueue( const MQTTAgentContext_t * pAgentContext,
                                        uint32_t blockTimeMs );
 
 /**
- * @brief Process a #Command_t.
+ * @brief Process a #Command struct.
  *
  * @note This agent does not check existing subscriptions before sending a
  * SUBSCRIBE or UNSUBSCRIBE packet. If a subscription already exists, then

--- a/source/mqtt_agent.c
+++ b/source/mqtt_agent.c
@@ -90,7 +90,7 @@ static AckInfo_t * getAwaitingOperation( MQTTAgentContext_t * pAgentContext,
  * @param[in] pCommandCompleteCallbackContext Context and necessary structs for command.
  * @param[out] pCommand Pointer to initialized command.
  *
- * @return `MQTTSuccess` if all necessary fields for the command are passed,
+ * @return #MQTTSuccess if all necessary fields for the command are passed,
  * else an enumerated error code.
  */
 static MQTTStatus_t createCommand( CommandType_t commandType,
@@ -109,7 +109,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
  * Blocked state (so not consuming any CPU time) for the command to be posted to the
  * queue should the queue already be full.
  *
- * @return MQTTSuccess if the command was added to the queue, else an enumerated
+ * @return #MQTTSuccess if the command was added to the queue, else an enumerated
  * error code.
  */
 static MQTTStatus_t addCommandToQueue( const MQTTAgentContext_t * pAgentContext,
@@ -186,7 +186,7 @@ static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContex
  * Blocked state, so not consuming any CPU time) for the command to be posted to the
  * MQTT agent should the MQTT agent's event queue be full.
  *
- * @return MQTTSuccess if the command was posted to the MQTT agent's event queue.
+ * @return #MQTTSuccess if the command was posted to the MQTT agent's event queue.
  * Otherwise an enumerated error code.
  */
 static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
@@ -215,7 +215,7 @@ static void concludeCommand( const MQTTAgentContext_t * pAgentContext,
  *
  * @param[in] pMqttAgentContext Agent context for the MQTT connection.
  *
- * @return MQTTSuccess if all publishes resent successfully, else error code
+ * @return #MQTTSuccess if all publishes resent successfully, else error code
  * from #MQTT_Publish.
  */
 static MQTTStatus_t resendPublishes( MQTTAgentContext_t * pMqttAgentContext );


### PR DESCRIPTION
*Description*:
Adds a GitHub Actions check for doxygen documentation, and links to external MQTT documentation. Since the `Command_t` typedef and struct definition are in separate files, doxygen has issues resolving references to it. This works around it by referring to the struct itself in our docs instead of the typedef.

