### PR TITLE
Change void to MQTTAgentCommandContext_t

### DIFF
--- a/source/include/core_mqtt_agent.h
+++ b/source/include/core_mqtt_agent.h
@@ -118,7 +118,7 @@ typedef struct MQTTAgentCommandContext MQTTAgentCommandContext_t;
  * application wants to enqueue command(s) with non-zero blocking time, the
  * callback can notify a different task to enqueue command(s) to the MQTT agent.
  */
-typedef void (* MQTTAgentCommandCallback_t )( void * pCmdCallbackContext,
+typedef void (* MQTTAgentCommandCallback_t )( MQTTAgentCommandContext_t * pCmdCallbackContext,
                                               MQTTAgentReturnInfo_t * pReturnInfo );
 
 /**
@@ -445,7 +445,7 @@ MQTTStatus_t MQTTAgent_CancelAll( MQTTAgentContext_t * pMqttAgentContext );
  * MQTTAgentSubscribeArgs_t subscribeArgs = { 0 };
  *
  * // Function for command complete callback.
- * void subscribeCmdCompleteCb( void * pCmdCallbackContext,
+ * void subscribeCmdCompleteCb( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                              MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -506,7 +506,7 @@ MQTTStatus_t MQTTAgent_Subscribe( const MQTTAgentContext_t * pMqttAgentContext,
  * MQTTAgentSubscribeArgs_t unsubscribeArgs = { 0 };
  *
  * // Function for command complete callback.
- * void unsubscribeCmdCompleteCb( void * pCmdCallbackContext,
+ * void unsubscribeCmdCompleteCb( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                                MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -565,7 +565,7 @@ MQTTStatus_t MQTTAgent_Unsubscribe( const MQTTAgentContext_t * pMqttAgentContext
  * MQTTPublishInfo_t publishInfo = { 0 };
  *
  * // Function for command complete callback.
- * void publishCmdCompleteCb( void * pCmdCallbackContext,
+ * void publishCmdCompleteCb( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                            MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -622,7 +622,7 @@ MQTTStatus_t MQTTAgent_Publish( const MQTTAgentContext_t * pMqttAgentContext,
  * MQTTAgentCommandInfo_t commandInfo = { 0 };
  *
  * // Function for command complete callback.
- * void cmdCompleteCb( void * pCmdCallbackContext,
+ * void cmdCompleteCb( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                     MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -679,7 +679,7 @@ MQTTStatus_t MQTTAgent_ProcessLoop( const MQTTAgentContext_t * pMqttAgentContext
  * MQTTAgentCommandInfo_t commandInfo = { 0 };
  *
  * // Function for command complete callback.
- * void pingRequestCompleteCb( void * pCmdCallbackContext,
+ * void pingRequestCompleteCb( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                             MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -773,7 +773,7 @@ MQTTStatus_t MQTTAgent_Ping( const MQTTAgentContext_t * pMqttAgentContext,
  * connectArgs.timeoutMs = 500;
  *
  * // Function for command complete callback.
- * void connectCmdCallback( void * pCmdCallbackContext,
+ * void connectCmdCallback( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                          MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -830,7 +830,7 @@ MQTTStatus_t MQTTAgent_Connect( const MQTTAgentContext_t * pMqttAgentContext,
  * MQTTAgentCommandInfo_t commandInfo = { 0 };
  *
  * // Function for command complete callback.
- * void disconnectCmdCallback( void * pCmdCallbackContext,
+ * void disconnectCmdCallback( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                             MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.
@@ -885,7 +885,7 @@ MQTTStatus_t MQTTAgent_Disconnect( const MQTTAgentContext_t * pMqttAgentContext,
  * MQTTAgentCommandInfo_t commandInfo = { 0 };
  *
  * // Function for command complete callback.
- * void terminateCallback( void * pCmdCallbackContext,
+ * void terminateCallback( MQTTAgentCommandContext_t * pCmdCallbackContext,
  *                         MQTTAgentReturnInfo_t * pReturnInfo );
  *
  * // Fill the command information.

--- a/test/unit-test/mqtt_agent_utest.c
+++ b/test/unit-test/mqtt_agent_utest.c
@@ -230,16 +230,12 @@ static void stubPublishCallback( MQTTAgentContext_t * pMqttAgentContext,
     publishCallbackCount++;
 }
 
-static void stubCompletionCallback( void * pCommandCompletionContext,
+static void stubCompletionCallback( MQTTAgentCommandContext_t * pCommandCompletionContext,
                                     MQTTAgentReturnInfo_t * pReturnInfo )
 {
-    MQTTAgentCommandContext_t * pCastContext;
-
-    pCastContext = ( MQTTAgentCommandContext_t * ) pCommandCompletionContext;
-
-    if( pCastContext != NULL )
+    if( pCommandCompletionContext != NULL )
     {
-        pCastContext->returnStatus = pReturnInfo->returnCode;
+        pCommandCompletionContext->returnStatus = pReturnInfo->returnCode;
     }
 
     commandCompleteCallbackCount++;


### PR DESCRIPTION
*Description*:
The first parameter of the command completion callback is the command context pointer, which does not need to be `void *` and can be `MQTTAgentCommandContext_t *`.
