### PR TITLE
Update memory table config for tagging

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -3,9 +3,18 @@
     "src": [
         "source/core_mqtt_agent.c",
         "source/core_mqtt_agent_command_functions.c",
-        "source/dependency/coreMQTT/source/core_mqtt.c",
-        "source/dependency/coreMQTT/source/core_mqtt_state.c",
-        "source/dependency/coreMQTT/source/core_mqtt_serializer.c"
+        {
+          "file": "source/dependency/coreMQTT/source/core_mqtt.c",
+          "tag": "coreMQTT"
+        },
+        {
+          "file": "source/dependency/coreMQTT/source/core_mqtt_state.c",
+          "tag": "coreMQTT"
+        },
+        {
+          "file": "source/dependency/coreMQTT/source/core_mqtt_serializer.c",
+          "tag": "coreMQTT"
+        }
     ],
     "include": [
         "source/include",

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -18,17 +18,17 @@
         <td><center>0.2K</center></td>
     </tr>
     <tr>
-        <td>core_mqtt.c</td>
+        <td>core_mqtt.c (coreMQTT)</td>
         <td><center>3.0K</center></td>
         <td><center>2.6K</center></td>
     </tr>
     <tr>
-        <td>core_mqtt_state.c</td>
+        <td>core_mqtt_state.c (coreMQTT)</td>
         <td><center>1.4K</center></td>
         <td><center>1.1K</center></td>
     </tr>
     <tr>
-        <td>core_mqtt_serializer.c</td>
+        <td>core_mqtt_serializer.c (coreMQTT)</td>
         <td><center>2.5K</center></td>
         <td><center>2.0K</center></td>
     </tr>


### PR DESCRIPTION
Updates the memory statistics config to use the tagging feature to tag coreMQTT files.