### PR TITLE
Fix doxygen generation by including coreMQTT docs

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -9,3 +9,16 @@ jobs:
     steps:
       - name: Doxygen generation
         uses: FreeRTOS/CI-CD-Github-Actions/doxygen-generation@main
+        with:
+          generate_command: |
+            # generate coreMQTT docs
+            git submodule update --init --checkout source/dependency/coreMQTT
+            cd source/dependency/coreMQTT
+            doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
+            cd ../../..
+            # generate coreMQTT-Agent docs
+            ( cat docs/doxygen/config.doxyfile;
+              echo "TAGFILES = source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag=coreMQTT"
+            ) | doxygen - 2>&1 | tee -a doxyoutput.txt
+            mv source/dependency/coreMQTT/docs/doxygen/output/html docs/doxygen/output/html/coreMQTT
+            if [ "$(wc -c < doxyoutput.txt | bc)" = "0" ]; then exit 0; else exit 1; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version_number }}
           add_release: "true"
+          generate_command: |
+            # generate coreMQTT docs
+            git submodule update --init --checkout source/dependency/coreMQTT
+            cd source/dependency/coreMQTT
+            doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
+            cd ../../..
+            # generate coreMQTT-Agent docs
+            ( cat docs/doxygen/config.doxyfile;
+              echo "TAGFILES = source/dependency/coreMQTT/docs/doxygen/output/mqtt.tag=coreMQTT"
+            ) | doxygen - 2>&1 | tee -a doxyoutput.txt
+            mv source/dependency/coreMQTT/docs/doxygen/output/html docs/doxygen/output/html/coreMQTT
+            if [ "$(wc -c < doxyoutput.txt | bc)" = "0" ]; then exit 0; else exit 1; fi
   create-release:
     needs:
       - create-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
           path: zip-check/coreMQTT-Agent-${{ github.event.inputs.version_number }}.zip
   deploy-doxygen:
     needs: tag-commit
+    if: ${{ ( github.event.inputs.delete_existing_tag_release == 'true' && success() )  || ( github.event.inputs.delete_existing_tag_release == 'false' && always() ) }}
     name: Deploy doxygen documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The doxygen action as used by other repos does not work due to the dependency on the coreMQTT docs. This generates and includes the coreMQTT docs in the coreMQTT-Agent bundle.