### PR TITLE
Update coreMQTT submodule pointer

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -285,4 +285,5 @@ usernamelength
 utest
 uxcontrolandlengthbytes
 willinfo
+writev
 www

--- a/test/unit-test/config/core_mqtt_config.h
+++ b/test/unit-test/config/core_mqtt_config.h
@@ -137,28 +137,25 @@
 
 
 /**
- * @brief The maximum duration between non-empty network transmissions while
- * sending an MQTT packet via the #MQTT_ProcessLoop or #MQTT_ReceiveLoop
- * API functions.
+ * @brief The maximum duration allowed to send an MQTT packet over the transport
+ * interface.
  *
- * When sending an MQTT packet, the transport send function may be called multiple
- * times until all of the required number of bytes are sent.
- * This timeout represents the maximum duration that is allowed for no data
- * transmission over the network through the transport send function.
+ * When sending an MQTT packet, the transport send or writev functions may be
+ * called multiple times until all of the required number of bytes are sent.
+ * This timeout represents the maximum duration that is allowed to send the MQTT
+ * packet while calling the transport send or writev functions.
  *
- * If the timeout expires, the #MQTT_ProcessLoop and #MQTT_ReceiveLoop functions
- * return #MQTTSendFailed.
+ * If the timeout expires, #MQTTSendFailed will be returned by the public API
+ * functions.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * is supplied to the library, then #MQTT_SEND_RETRY_TIMEOUT_MS MUST be set to 0.
+ * is supplied to the library, then #MQTT_SEND_TIMEOUT_MS MUST be set to 0.
  *
- * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a small
- * timeout value. <br>
- * <b>Default value:</b> `10`
+ * <b>Possible values:</b> Any positive 32 bit integer. <br>
+ * <b>Default value:</b> `20000`
  *
  */
-
-#define MQTT_SEND_RETRY_TIMEOUT_MS    ( 10U )
+#define MQTT_SEND_TIMEOUT_MS    ( 10U )
 
 
 /**


### PR DESCRIPTION
This PR updates the coreMQTT submodule pointer to point to v2.1.0 release.

It also updates one config macro name to be compatible with coreMQTT changes.