### PR TITLE
Cast MQTTAgentCommandType_t to unsigned

### DIFF
--- a/source/core_mqtt_agent.c
+++ b/source/core_mqtt_agent.c
@@ -562,9 +562,9 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
 
     if( pCommand != NULL )
     {
-        assert( pCommand->commandType < NUM_COMMANDS );
+        assert( ( unsigned int ) pCommand->commandType < ( unsigned int ) NUM_COMMANDS );
 
-        if( ( pCommand->commandType >= NONE ) && ( pCommand->commandType < NUM_COMMANDS ) )
+        if( ( unsigned int ) pCommand->commandType < ( unsigned int ) NUM_COMMANDS )
         {
             commandFunction = pCommandFunctionTable[ pCommand->commandType ];
             pCommandArgs = pCommand->pArgs;


### PR DESCRIPTION
## Background

The underlying integer type of an enum in C is implementation-defined. 
It may be compatible with one of: 
* char 
* unsigned integers
* signed integers

IAR Embedded Workbench decides to make the enum unsigned only to warn against checking an enum value is positive.
Other compilers may emit signed integers for the enum, so an explicit cast is needed.