### PR TITLE
Update Agent to treat MQTTNeedMoreBytes correctly

### DIFF
--- a/source/core_mqtt_agent.c
+++ b/source/core_mqtt_agent.c
@@ -613,6 +613,12 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
         } while( pMqttAgentContext->packetReceivedInLoop );
     }
 
+    if( operationStatus == MQTTNeedMoreBytes )
+    {
+        /* Reset the operation status as MQTTNeedMoreBytes is not an error condition. */
+        operationStatus = MQTTSuccess;
+    }
+
     /* Set the flag to break from the command loop. */
     *pEndLoop = ( commandOutParams.endLoop || ( operationStatus != MQTTSuccess ) );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Currently, the Agent drops the connection in case a partial packet is received. Which is not correct given that coreMQTT can handle partial packets correctly.

This PR fixes that by resetting the return value of the `processCommand` function when coreMQTT returns `MQTTNeedMoreBytes`.

Test Steps
-----------
Make sure that the server sends partial MQTT packets to the client. Without these changes, the library will terminate the connection.
With this change in place the library will not drop the connection and work correctly.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
