### PR TITLE
Move static arrays from function MQTTAgent_Init to MQTTAgentContext_t.

### DIFF
--- a/source/core_mqtt_agent.c
+++ b/source/core_mqtt_agent.c
@@ -973,18 +973,6 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
 {
     MQTTStatus_t returnStatus;
 
-    /**
-     * @brief Array used to maintain the outgoing publish records and their
-     * state by the coreMQTT library.
-     */
-    static MQTTPubAckInfo_t pIncomingPublishRecords[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ];
-
-    /**
-     * @brief Array used to maintain the outgoing publish records and their
-     * state by the coreMQTT library.
-     */
-    static MQTTPubAckInfo_t pOutgoingPublishRecords[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ];
-
     if( ( pMqttAgentContext == NULL ) ||
         ( pMsgInterface == NULL ) ||
         ( pTransportInterface == NULL ) ||
@@ -1017,9 +1005,9 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
             if( returnStatus == MQTTSuccess )
             {
                 returnStatus = MQTT_InitStatefulQoS( &( pMqttAgentContext->mqttContext ),
-                                                     pOutgoingPublishRecords,
+                                                     pMqttAgentContext->pOutgoingPublishRecords,
                                                      MQTT_AGENT_MAX_OUTSTANDING_ACKS,
-                                                     pIncomingPublishRecords,
+                                                     pMqttAgentContext->pIncomingPublishRecords,
                                                      MQTT_AGENT_MAX_OUTSTANDING_ACKS );
             }
         }

--- a/source/include/core_mqtt_agent.h
+++ b/source/include/core_mqtt_agent.h
@@ -151,12 +151,14 @@ typedef void (* MQTTAgentIncomingPublishCallback_t )( struct MQTTAgentContext * 
  */
 typedef struct MQTTAgentContext
 {
-    MQTTContext_t mqttContext;                                          /**< MQTT connection information used by coreMQTT. */
-    MQTTAgentMessageInterface_t agentInterface;                         /**< Struct of function pointers for agent messaging. */
-    MQTTAgentAckInfo_t pPendingAcks[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ]; /**< List of pending acknowledgment packets. */
-    MQTTAgentIncomingPublishCallback_t pIncomingCallback;               /**< Callback to invoke for incoming publishes. */
-    void * pIncomingCallbackContext;                                    /**< Context for incoming publish callback. */
-    bool packetReceivedInLoop;                                          /**< Whether a MQTT_ProcessLoop() call received a packet. */
+    MQTTContext_t mqttContext;                                                   /**< MQTT connection information used by coreMQTT. */
+    MQTTAgentMessageInterface_t agentInterface;                                  /**< Struct of function pointers for agent messaging. */
+    MQTTAgentAckInfo_t pPendingAcks[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ];          /**< List of pending acknowledgment packets. */
+    MQTTAgentIncomingPublishCallback_t pIncomingCallback;                        /**< Callback to invoke for incoming publishes. */
+    void * pIncomingCallbackContext;                                             /**< Context for incoming publish callback. */
+    bool packetReceivedInLoop;                                                   /**< Whether a MQTT_ProcessLoop() call received a packet. */
+    MQTTPubAckInfo_t pIncomingPublishRecords[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ]; /**< Array used to maintain the incoming publish records and their state by the coreMQTT library. */
+    MQTTPubAckInfo_t pOutgoingPublishRecords[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ]; /**< Array used to maintain the outgoing publish records and their state by the coreMQTT library. */
 } MQTTAgentContext_t;
 
 /**


### PR DESCRIPTION
<!--- Title -->
Move static arrays from function MQTTAgent_Init to MQTTAgentContext_t.

Description
-----------
<!--- Describe your changes in detail. -->
Move `pIncomingPublishRecords` and `pOutgoingPublishRecords` into MQTTAgentContext_t for better maintainability.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Execute unit-test cases

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#130 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
