### PR TITLE
Fix coreMQTT v5 API signatures in doxygen examples

### DIFF
--- a/source/include/core_mqtt_agent.h
+++ b/source/include/core_mqtt_agent.h
@@ -351,7 +351,7 @@ MQTTStatus_t MQTTAgent_Init( MQTTAgentContext_t * pMqttAgentContext,
  * {
  *    // Terminate command was processed but MQTT connection was not
  *    // closed. Thus, need to close both MQTT and socket connections.
- *    status = MQTT_Disconnect( &( mqttAgentContext.mqttContext ) );
+ *    status = MQTT_Disconnect( &( mqttAgentContext.mqttContext ), NULL, NULL );
  *    assert( status == MQTTSuccess );
  *    Platform_DisconnectNetwork( mqttAgentContext.mqttContext.transportInterface.pNetworkContext );
  * }
@@ -394,7 +394,7 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext );
  * // Refer to the MQTT_Connect API for a more detailed example.
  *
  * // Attempt to resume session with the broker.
- * status = MQTT_Connect( &( mqttAgentContext.mqttContext ), &connectInfo, &willInfo, 100, &sessionPresent )
+ * status = MQTT_Connect( &( mqttAgentContext.mqttContext ), &connectInfo, &willInfo, 100, &sessionPresent, NULL, NULL );
  *
  * if( status == MQTTSuccess )
  * {


### PR DESCRIPTION
Fixes #139

The doxygen examples in `core_mqtt_agent.h` called coreMQTT APIs with pre-v5 signatures, which no longer compile against the pinned coreMQTT v5.0.2 submodule.

- `MQTTAgent_CommandLoop` example: `MQTT_Disconnect` now takes property-builder and reason-code arguments (passing `NULL, NULL`).
- `MQTTAgent_ResumeSession` example: `MQTT_Connect` now takes property-builder and will-property-builder arguments (passing `NULL, NULL`); also added the missing trailing semicolon.

The `MQTT_Disconnect` case is the one reported in #139. The `MQTT_Connect` example was found while sweeping the other coreMQTT API examples. Implementation code already uses the correct v5 signatures, so this is a documentation-only change.

Closes #139 